### PR TITLE
Add cross-platform build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ NoNameEngine est un moteur de jeu basé sur un système Entity Component System 
 ### Compilation
 
 ```sh
-mkdir build
-cd build
-cmake ..
-make
+# On Linux/macOS
+./scripts/build.sh
+
+# On Windows
+scripts\build.bat
 ```
 
 ## Architecture

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,0 +1,16 @@
+@echo off
+setlocal enableextensions
+
+set "ROOT_DIR=%~dp0.."
+set "BUILD_DIR=%ROOT_DIR%\build"
+
+if "%VCPKG_ROOT%"=="" (
+    set "VCPKG_PATH=%ROOT_DIR%\vcpkg"
+) else (
+    set "VCPKG_PATH=%VCPKG_ROOT%"
+)
+
+set "TOOLCHAIN=%VCPKG_PATH%\scripts\buildsystems\vcpkg.cmake"
+
+cmake -B "%BUILD_DIR%" -S "%ROOT_DIR%" -DCMAKE_TOOLCHAIN_FILE="%TOOLCHAIN%" %*
+cmake --build "%BUILD_DIR%"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Directory of this script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/build}"
+
+mkdir -p "$BUILD_DIR"
+
+# Use VCPKG_ROOT if set, otherwise assume ../vcpkg relative to repository root
+VCPKG_PATH="${VCPKG_ROOT:-$ROOT_DIR/vcpkg}"
+TOOLCHAIN_FILE="$VCPKG_PATH/scripts/buildsystems/vcpkg.cmake"
+
+cmake -B "$BUILD_DIR" -S "$ROOT_DIR" -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" "$@"
+cmake --build "$BUILD_DIR"


### PR DESCRIPTION
## Summary
- provide portable `scripts/build.sh` and `scripts/build.bat`
- document the helper scripts in README

## Testing
- `BUILD_DIR=build_linux ./scripts/build.sh` *(fails: CMAKE_C_COMPILER not set)*

------
https://chatgpt.com/codex/tasks/task_e_686cc737278c832aa410797772b44715