### PR TITLE
Add minimal unit tests and integrate with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,17 @@
 cmake_minimum_required(VERSION 3.15)
 project(NNEngine)
 
-# Désactive la génération de ZERO_CHECK
+# Disable regeneration target
 set(CMAKE_SUPPRESS_REGENERATION true)
 
-# Désactive ALL_BUILD
+# Disable ALL_BUILD
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMakeTargets")
 
-# Ajouter les sous-projets (le moteur et le jeu)
+# Add subprojects
 add_subdirectory(NoNameEngine)
 add_subdirectory(NNE_GameTemplate)
+
+# Enable tests
+enable_testing()
+add_subdirectory(NoNameEngine/test)

--- a/NoNameEngine/CMakeLists.txt
+++ b/NoNameEngine/CMakeLists.txt
@@ -4,15 +4,12 @@ project(NoNameEngine)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-#set(CMAKE_PREFIX_PATH "C:/Users/schev/vcpkg/installed/x64-windows")
-#set(CMAKE_PREFIX_PATH "C:/vcpkg/installed/x64-windows")
-
 set(SOURCES
     src/Application.cpp
     src/VulkanManager.cpp
     src/AEntity.cpp
     src/AComponent.cpp
-    src/AScene.cpp    
+    src/AScene.cpp
     src/MeshComponent.cpp
     src/TransformComponent.cpp
     src/CameraComponent.cpp
@@ -30,9 +27,9 @@ set(HEADERS
     include/VulkanManager.h
     include/AEntity.h
     include/AComponent.h
-    include/AScene.h  
-    include/MeshComponent.h  
-    include/TransformComponent.h  
+    include/AScene.h
+    include/MeshComponent.h
+    include/TransformComponent.h
     include/CameraComponent.h
     include/PhysicsManager.h
     include/ColliderComponent.h
@@ -45,13 +42,13 @@ set(HEADERS
 
 add_compile_definitions(SHADER_PATH="${CMAKE_SOURCE_DIR}/NoNameEngine/shaders")
 
-# Création d'une bibliothèque statique
+# Build static library
 add_library(NoNameEngine STATIC ${SOURCES} ${HEADERS})
 
-# Ajout des dossiers d'include pour les autres projets
+# Include directories for other projects
 target_include_directories(NoNameEngine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-# Lier Vulkan, GLFW, glm, etc.
+# Link Vulkan, GLFW, glm, etc.
 find_package(glfw3 CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(Vulkan REQUIRED)
@@ -59,3 +56,6 @@ find_package(tinyobjloader CONFIG REQUIRED)
 find_package(Jolt CONFIG REQUIRED)
 
 target_link_libraries(NoNameEngine PUBLIC glfw glm::glm Vulkan::Vulkan tinyobjloader::tinyobjloader Jolt::Jolt)
+
+# Tests
+add_subdirectory(test)

--- a/NoNameEngine/test/CMakeLists.txt
+++ b/NoNameEngine/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(NoNameEngine_tests test_main.cpp)
+
+# Link the engine library
+# The engine target is NoNameEngine defined in parent directory
+
+target_link_libraries(NoNameEngine_tests PRIVATE NoNameEngine)
+
+add_test(NAME NoNameEngineTests COMMAND NoNameEngine_tests)

--- a/NoNameEngine/test/test_main.cpp
+++ b/NoNameEngine/test/test_main.cpp
@@ -1,6 +1,29 @@
 #include <iostream>
+#include <cassert>
+#include "TransformComponent.h"
 
-int main() {
-    std::cout << "Running tests...\n";
-    return 0; // Succès
+static void test_default_transform()
+{
+    NNE::TransformComponent t;
+    assert(t.position == glm::vec3(0.0f));
+    assert(t.rotation == glm::vec3(0.0f));
+    assert(t.scale == glm::vec3(1.0f, 1.0f, 1.0f));
+}
+
+static void test_parent_relationship()
+{
+    NNE::TransformComponent parent;
+    NNE::TransformComponent child;
+    child.SetParent(&parent);
+    assert(child.parent == &parent);
+    assert(parent.children.size() == 1);
+    assert(parent.children[0] == &child);
+}
+
+int main()
+{
+    test_default_transform();
+    test_parent_relationship();
+    std::cout << "All tests passed" << std::endl;
+    return 0;
 }


### PR DESCRIPTION
## Summary
- add simple tests for `TransformComponent`
- enable CTest in the main CMakeLists
- include test target in engine build

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glfw3")*

------
https://chatgpt.com/codex/tasks/task_e_6877c9b1ebf0832aa2b4a6f5b64d0615