### PR TITLE
Fix header include in RigidbodyComponent

### DIFF
--- a/src/src/RigidbodyComponent.cpp
+++ b/src/src/RigidbodyComponent.cpp
@@ -1,4 +1,4 @@
-﻿#include "RigidBodyComponent.h"
+﻿#include "RigidbodyComponent.h"
 #include "Application.h"
 #include "TransformComponent.h"
 #include <Jolt/Physics/Body/BodyCreationSettings.h> 


### PR DESCRIPTION
## Summary
- correct header include name for RigidbodyComponent

## Testing
- `cmake -S . -B build` *(fails: Could not find glfw3)*

------
https://chatgpt.com/codex/tasks/task_e_687a25fe509c832aa224d5cc43a15fab