### PR TITLE
Add vcpkg installers for all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ NoNameEngine est un moteur de jeu basé sur un système Entity Component System 
 - GLM
 - tinyobjloader
 
+### Installer les dépendances
+Ce projet utilise [vcpkg](https://github.com/microsoft/vcpkg) pour gérer les bibliothèques tierces.
+Des scripts sont fournis pour installer automatiquement `vcpkg` ainsi que les packages requis.
+
+```sh
+# Linux/macOS
+./scripts/install_dependencies.sh
+
+# Windows
+scripts\install_dependencies.bat
+```
+
+Une fois les dépendances en place, vous pouvez générer la solution comme décrit ci-dessous.
+
 ### Compilation
 
 ```sh

--- a/scripts/install_dependencies.bat
+++ b/scripts/install_dependencies.bat
@@ -1,0 +1,31 @@
+@echo off
+setlocal enableextensions
+
+REM Directory of this script
+set "ROOT_DIR=%~dp0.."
+
+REM Use VCPKG_ROOT if set, otherwise default to ..\vcpkg
+if defined VCPKG_ROOT (
+    echo [INFO] Using VCPKG_ROOT: %VCPKG_ROOT%
+    set "VCPKG_PATH=%VCPKG_ROOT%"
+) else (
+    echo [WARN] VCPKG_ROOT not defined, using default: %ROOT_DIR%\vcpkg
+    set "VCPKG_PATH=%ROOT_DIR%\vcpkg"
+)
+
+REM Install vcpkg if missing
+if not exist "%VCPKG_PATH%\vcpkg.exe" (
+    echo [INFO] Cloning vcpkg...
+    git clone https://github.com/microsoft/vcpkg "%VCPKG_PATH%"
+    call "%VCPKG_PATH%\bootstrap-vcpkg.bat"
+)
+
+REM Install required packages
+"%VCPKG_PATH%\vcpkg.exe" install glfw3 glm stb vulkan tinyobjloader joltphysics
+
+echo Dependencies installed using vcpkg.
+echo You can now build the project with:
+echo     cmake -B build -S "%ROOT_DIR%" -DCMAKE_TOOLCHAIN_FILE="%VCPKG_PATH%\scripts\buildsystems\vcpkg.cmake"
+echo     cmake --build build
+
+endlocal

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VCPKG_DIR="${VCPKG_ROOT:-$ROOT_DIR/vcpkg}"
+
+# Basic build tools if using apt
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y build-essential cmake git curl
+fi
+
+if [ ! -d "$VCPKG_DIR" ]; then
+    git clone https://github.com/microsoft/vcpkg.git "$VCPKG_DIR"
+    "$VCPKG_DIR/bootstrap-vcpkg.sh"
+fi
+
+PACKAGES="glfw3 glm stb vulkan tinyobjloader joltphysics"
+"$VCPKG_DIR/vcpkg" install $PACKAGES
+
+cat <<EOS
+
+Dependencies installed using vcpkg. You can now build the project with:
+    cmake -B build -S "$ROOT_DIR" -DCMAKE_TOOLCHAIN_FILE="$VCPKG_DIR/scripts/buildsystems/vcpkg.cmake"
+    cmake --build build
+EOS
+


### PR DESCRIPTION
## Summary
- document Windows and Linux dependency installation
- add Windows batch script to install vcpkg packages

## Testing
- `./scripts/install_dependencies.sh` *(fails: apt repositories 403 Forbidden)*
- `cmake -B build -S .` *(fails: Could not find glfw3Config.cmake)*

