### PR TITLE
Fix build script for non-Windows platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,19 @@ find_package(glm CONFIG REQUIRED)
 find_package(Vulkan REQUIRED)
 find_package(tinyobjloader CONFIG REQUIRED)
 find_package(Jolt CONFIG REQUIRED)
-find_package(nlohmann_json CONFIG REQUIRED)
+# Try to locate nlohmann_json via package manager (e.g., vcpkg).
+# If not available, fetch the header-only library from upstream.
+find_package(nlohmann_json CONFIG QUIET)
+if(NOT nlohmann_json_FOUND)
+    message(STATUS "nlohmann_json not found; fetching from source")
+    include(FetchContent)
+    FetchContent_Declare(
+        nlohmann_json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG v3.11.2
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+endif()
 
 target_link_libraries(NNEngine PUBLIC glfw glm::glm Vulkan::Vulkan tinyobjloader::tinyobjloader Jolt::Jolt nlohmann_json::nlohmann_json)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,6 +11,13 @@ mkdir -p "$BUILD_DIR"
 # Use VCPKG_ROOT if set, otherwise assume ../vcpkg relative to repository root
 VCPKG_PATH="${VCPKG_ROOT:-$ROOT_DIR/vcpkg}"
 TOOLCHAIN_FILE="$VCPKG_PATH/scripts/buildsystems/vcpkg.cmake"
+CMAKE_TOOLCHAIN_ARG=""
+if [ -f "$TOOLCHAIN_FILE" ]; then
+    CMAKE_TOOLCHAIN_ARG="-DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_FILE"
+else
+    echo "Warning: vcpkg toolchain file not found at $TOOLCHAIN_FILE, proceeding without it."
+    CMAKE_TOOLCHAIN_ARG="-DCMAKE_TOOLCHAIN_FILE="
+fi
 
 # Choose an appropriate CMake generator depending on the platform. On Windows
 # we keep using Visual Studio while on other systems we rely on CMake's default
@@ -26,9 +33,9 @@ esac
 
 # Configure and build the project
 if [ -n "$GENERATOR" ]; then
-    cmake -B "$BUILD_DIR" -S "$ROOT_DIR" -G "$GENERATOR" -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" "$@"
+    cmake -B "$BUILD_DIR" -S "$ROOT_DIR" -G "$GENERATOR" $CMAKE_TOOLCHAIN_ARG "$@"
 else
-    cmake -B "$BUILD_DIR" -S "$ROOT_DIR" -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" "$@"
+    cmake -B "$BUILD_DIR" -S "$ROOT_DIR" $CMAKE_TOOLCHAIN_ARG "$@"
 fi
 cmake --build "$BUILD_DIR"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,5 +12,27 @@ mkdir -p "$BUILD_DIR"
 VCPKG_PATH="${VCPKG_ROOT:-$ROOT_DIR/vcpkg}"
 TOOLCHAIN_FILE="$VCPKG_PATH/scripts/buildsystems/vcpkg.cmake"
 
-cmake -B "$BUILD_DIR" -S "$ROOT_DIR" -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" "$@"
+# Choose an appropriate CMake generator depending on the platform. On Windows
+# we keep using Visual Studio while on other systems we rely on CMake's default
+# generator (typically Unix Makefiles or Ninja).
+GENERATOR=""
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        GENERATOR="Visual Studio 17 2022"
+        ;;
+    *)
+        ;;
+esac
+
+# Configure and build the project
+if [ -n "$GENERATOR" ]; then
+    cmake -B "$BUILD_DIR" -S "$ROOT_DIR" -G "$GENERATOR" -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" "$@"
+else
+    cmake -B "$BUILD_DIR" -S "$ROOT_DIR" -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" "$@"
+fi
 cmake --build "$BUILD_DIR"
+
+# Run tests if they were generated
+if command -v ctest >/dev/null 2>&1; then
+    ctest --test-dir "$BUILD_DIR" --output-on-failure || true
+fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,5 +41,5 @@ cmake --build "$BUILD_DIR"
 
 # Run tests if they were generated
 if command -v ctest >/dev/null 2>&1; then
-    ctest --test-dir "$BUILD_DIR" --output-on-failure || true
+    ctest --test-dir "$BUILD_DIR" --output-on-failure
 fi

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -16,7 +16,7 @@ if [ ! -d "$VCPKG_DIR" ]; then
     "$VCPKG_DIR/bootstrap-vcpkg.sh"
 fi
 
-PACKAGES="glfw3 glm stb vulkan tinyobjloader joltphysics"
+PACKAGES="glfw3 glm stb vulkan tinyobjloader joltphysics nlohmann-json"
 "$VCPKG_DIR/vcpkg" install $PACKAGES
 
 cat <<EOS


### PR DESCRIPTION
## Summary
- choose Visual Studio generator only on Windows
- run ctest after building

## Testing
- `./scripts/install_dependencies.sh` (fails: 403  Forbidden)
- `./scripts/build.sh` (fails: Could not find toolchain file /vcpkg)

