### PR TITLE
Organize engine classes into structured namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Le moteur est basé sur un ECS avec les composants suivants :
 
 ### Classes principales
 
-#### `NNE::Application`
+#### `NNE::Systems::Application`
 Gère l'initialisation et la boucle principale du moteur.
 
 - `void Init()` : Initialise Vulkan et les entités.
@@ -68,7 +68,7 @@ Classe de base pour tous les composants.
 - `virtual void Update(float deltaTime)`
 - `virtual void LateUpdate(float deltaTime)`
 
-#### `NNE::TransformComponent`
+#### `NNE::Component::TransformComponent`
 Gère la position, la rotation et l'échelle d'une entité.
 
 - `glm::vec3 position` : Position dans l'espace.
@@ -76,7 +76,7 @@ Gère la position, la rotation et l'échelle d'une entité.
 - `glm::vec3 scale` : Échelle de l'entité.
 - `glm::mat4 getModelMatrix()` : Retourne la matrice de transformation.
 
-#### `NNE::CameraComponent`
+#### `NNE::Component::Render::CameraComponent`
 Gère la caméra et sa projection.
 
 - `void SetPerspective(float fov, float aspectRatio, float nearPlane, float farPlane)`
@@ -84,7 +84,7 @@ Gère la caméra et sa projection.
 - `glm::mat4 GetViewMatrix()`
 - `glm::mat4 GetProjectionMatrix()`
 
-#### `NNE::MeshComponent`
+#### `NNE::Component::Render::MeshComponent`
 Gère le rendu des modèles 3D avec Vulkan.
 
 - `void SetModelPath(std::string path)`
@@ -92,7 +92,7 @@ Gère le rendu des modèles 3D avec Vulkan.
 - `std::string GetModelPath()`
 - `std::string GetTexturePath()`
 
-#### `NNE::VulkanManager`
+#### `NNE::Systems::VulkanManager`
 Gère l'initialisation et le rendu avec Vulkan.
 
 - `void initVulkan()`
@@ -102,7 +102,7 @@ Gère l'initialisation et le rendu avec Vulkan.
 - `void updateUniformBuffer(uint32_t currentImage)`
 - `void CleanUp()`
 
-#### `NNE::InputManager`
+#### `NNE::Systems::InputManager`
 Gère les entrées clavier et souris.
 
 - `static void Init(GLFWwindow* win)`
@@ -113,32 +113,32 @@ Gère les entrées clavier et souris.
 - `static glm::vec2 GetMousePosition()`
 - `static bool IsMouseButtonPressed(int button)`
 
-#### `NNE::PhysicsManager`
+#### `NNE::Systems::PhysicsManager`
 Interface avec Jolt Physics.
 
 - `void Initialize()`
 - `void Update(float deltaTime)`
 - `JPH::PhysicsSystem* GetPhysicsSystem()`
 
-#### `NNE::ColliderComponent`
+#### `NNE::Component::Physics::ColliderComponent`
 Classe mère pour les colliders.
 
 - `virtual void CreateShape()`
 - `virtual void OnHit(ColliderComponent* other)`
 - `virtual void OnTriggerHit(ColliderComponent* other)`
 
-#### `NNE::BoxColliderComponent`
+#### `NNE::Component::Physics::BoxColliderComponent`
 Collider en boîte.
 
 - `void Awake()`
 - `void CreateShape()`
 
-#### `NNE::PlaneCollider`
+#### `NNE::Component::Physics::PlaneCollider`
 Collider plan.
 
 - `void CreateShape()`
 
-#### `NNE::RigidbodyComponent`
+#### `NNE::Component::Physics::RigidbodyComponent`
 Gère un corps physique dynamique.
 
 - `void Awake()`
@@ -146,15 +146,15 @@ Gère un corps physique dynamique.
 - `void SetLinearVelocity(glm::vec3 velocity)`
 - `glm::vec3 GetLinearVelocity()`
 
-#### `NNE::MonoComponent`
+#### `NNE::Component::MonoComponent`
 Composant scriptable générique.
 
 - `void Awake()`
 - `void Start()`
 - `void Update(float deltaTime)`
 - `void LateUpdate(float deltaTime)`
-- `void OnHit(NNE::ColliderComponent* other)`
-- `void OnTriggerHit(NNE::ColliderComponent* other)`
+- `void OnHit(NNE::Component::Physics::ColliderComponent* other)`
+- `void OnTriggerHit(NNE::Component::Physics::ColliderComponent* other)`
 
 #### `Diagramme de classe`
 ![image](https://github.com/user-attachments/assets/39aa283d-5a06-489e-ba82-c189747c2691)
@@ -167,19 +167,19 @@ Un exemple minimal d'utilisation du moteur :
 
 ```cpp
 int main() {
-    NNE::Application app;
+    NNE::Systems::Application app;
     
     NNE::AEntity* entity = app.CreateEntity();
-    NNE::MeshComponent* MC = entity->AddComponent<NNE::MeshComponent>();
-    NNE::TransformComponent* TC = entity->AddComponent<NNE::TransformComponent>();
+    NNE::Component::Render::MeshComponent* MC = entity->AddComponent<NNE::Component::Render::MeshComponent>();
+    NNE::Component::TransformComponent* TC = entity->AddComponent<NNE::Component::TransformComponent>();
     // The engine expects the assets folder to be copied next to the executable
     // when building. Relative paths can then be used during runtime.
     MC->SetModelPath("../assets/viking_room.obj");
     MC->SetTexturePath("../assets/textures/viking_room.png");
     
     NNE::AEntity* camera = app.CreateEntity();
-    NNE::CameraComponent* CC = camera->AddComponent<NNE::CameraComponent>();
-    NNE::TransformComponent* TC2 = camera->AddComponent<NNE::TransformComponent>();
+    NNE::Component::Render::CameraComponent* CC = camera->AddComponent<NNE::Component::Render::CameraComponent>();
+    NNE::Component::TransformComponent* TC2 = camera->AddComponent<NNE::Component::TransformComponent>();
     TC2->position = glm::vec3(0.0f, 0.0f, 30.0f);
     app.VKManager->activeCamera = CC;
     

--- a/examples/include/PlayerController.h
+++ b/examples/include/PlayerController.h
@@ -5,7 +5,7 @@
 #include "AEntity.h"
 #include <glm/ext/vector_float3.hpp>
 
-class PlayerController : public NNE::MonoComponent
+class PlayerController : public NNE::Component::MonoComponent
 {
 private:
 	float speed = 10.0f;
@@ -18,6 +18,6 @@ public:
 	void Awake() override;
 	void Update(float deltaTime) override;
 
-	void OnHit(NNE::ColliderComponent* other) override;
+        void OnHit(NNE::Component::Physics::ColliderComponent* other) override;
 };
 

--- a/examples/src/Main.cpp
+++ b/examples/src/Main.cpp
@@ -2,43 +2,43 @@
 #include "../include/PlayerController.h"
 
 int main() {
-    NNE::Application app;
+    NNE::Systems::Application app;
 
-	NNE::AEntity* floor = app.CreateEntity();
-	//NNE::PlaneCollider* PC = floor->AddComponent<NNE::PlaneCollider>(glm::vec3(0, 1, 0), 10.0f);
-	NNE::TransformComponent* TCfloor = floor->GetComponent<NNE::TransformComponent>();
-	NNE::BoxColliderComponent* BCFloor = floor->AddComponent<NNE::BoxColliderComponent>(glm::vec3(100.0f, 0.50f, 100.0f));
-	NNE::RigidbodyComponent* RBCFloor = floor->AddComponent<NNE::RigidbodyComponent>(0.0f, true);
+        NNE::AEntity* floor = app.CreateEntity();
+        //NNE::Component::Physics::PlaneCollider* PC = floor->AddComponent<NNE::Component::Physics::PlaneCollider>(glm::vec3(0, 1, 0), 10.0f);
+        NNE::Component::TransformComponent* TCfloor = floor->GetComponent<NNE::Component::TransformComponent>();
+        NNE::Component::Physics::BoxColliderComponent* BCFloor = floor->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(100.0f, 0.50f, 100.0f));
+        NNE::Component::Physics::RigidbodyComponent* RBCFloor = floor->AddComponent<NNE::Component::Physics::RigidbodyComponent>(0.0f, true);
 	
 	TCfloor->position = glm::vec3(0.0f, -3.0f, 0.0f);
 
-	NNE::AEntity* entity = app.CreateEntity();
-	NNE::MeshComponent* MC = entity->AddComponent<NNE::MeshComponent>();
-	NNE::TransformComponent* TC = entity->GetComponent<NNE::TransformComponent>();
-	TC->position = glm::vec3(0.0f, 5.0f, 0.0f);
-	NNE::BoxColliderComponent* BCC = entity->AddComponent<NNE::BoxColliderComponent>(glm::vec3(1.0f, 1.0f, 1.0f));
-	NNE::RigidbodyComponent* RBC = entity->AddComponent<NNE::RigidbodyComponent>( 1.0f, false);
+        NNE::AEntity* entity = app.CreateEntity();
+        NNE::Component::Render::MeshComponent* MC = entity->AddComponent<NNE::Component::Render::MeshComponent>();
+        NNE::Component::TransformComponent* TC = entity->GetComponent<NNE::Component::TransformComponent>();
+        TC->position = glm::vec3(0.0f, 5.0f, 0.0f);
+        NNE::Component::Physics::BoxColliderComponent* BCC = entity->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(1.0f, 1.0f, 1.0f));
+        NNE::Component::Physics::RigidbodyComponent* RBC = entity->AddComponent<NNE::Component::Physics::RigidbodyComponent>( 1.0f, false);
 	
         MC->SetModelPath("../assets/models/viking_room.obj");
         MC->SetTexturePath("../assets/textures/viking_room.png");
 
-	NNE::AEntity* player = app.CreateEntity();
-	NNE::TransformComponent* TCplayer = player->GetComponent<NNE::TransformComponent>();
-	NNE::BoxColliderComponent* BCCplayer = player->AddComponent<NNE::BoxColliderComponent>(glm::vec3(1.0f, 1.0f, 1.0f));
-	NNE::RigidbodyComponent* RBCplayer = player->AddComponent<NNE::RigidbodyComponent>(1.0f, false);
-	PlayerController* PC = player->AddComponent<PlayerController>();
+        NNE::AEntity* player = app.CreateEntity();
+        NNE::Component::TransformComponent* TCplayer = player->GetComponent<NNE::Component::TransformComponent>();
+        NNE::Component::Physics::BoxColliderComponent* BCCplayer = player->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(1.0f, 1.0f, 1.0f));
+        NNE::Component::Physics::RigidbodyComponent* RBCplayer = player->AddComponent<NNE::Component::Physics::RigidbodyComponent>(1.0f, false);
+        PlayerController* PC = player->AddComponent<PlayerController>();
 
 	TCplayer->position = glm::vec3(0.0f, 0.0f, 5.0f);
 
-	NNE::AEntity* camera = app.CreateEntity();
-	NNE::CameraComponent* CC = camera->AddComponent<NNE::CameraComponent>();
-	NNE::TransformComponent* TC2 = camera->GetComponent<NNE::TransformComponent>();
+        NNE::AEntity* camera = app.CreateEntity();
+        NNE::Component::Render::CameraComponent* CC = camera->AddComponent<NNE::Component::Render::CameraComponent>();
+        NNE::Component::TransformComponent* TC2 = camera->GetComponent<NNE::Component::TransformComponent>();
 
 	TC2->SetParent(TCplayer);
 
 	CC->SetPerspective(45.0f, 16.0f / 9.0f, 0.1f, 100.0f);	
 	TC2->position = glm::vec3(0.0f, 0.0f, 0.0f);
-	app.VKManager->activeCamera = CC;
+        app.VKManager->activeCamera = CC;
 
     app.Init();
     app.Update();

--- a/examples/src/PlayerController.cpp
+++ b/examples/src/PlayerController.cpp
@@ -19,35 +19,35 @@ void PlayerController::Update(float deltaTime)
 {
 	direction = glm::vec3(0.0f);	
 
-	if (NNE::InputManager::IsKeyPressed(GLFW_KEY_W)) {
-		direction.z = 1;				
-	}
+        if (NNE::Systems::InputManager::IsKeyPressed(GLFW_KEY_W)) {
+                direction.z = 1;
+        }
 
-	if (NNE::InputManager::IsKeyPressed(GLFW_KEY_S)) {
-		direction.z = -1;
-	}	
+        if (NNE::Systems::InputManager::IsKeyPressed(GLFW_KEY_S)) {
+                direction.z = -1;
+        }
 
-	if (NNE::InputManager::IsKeyPressed(GLFW_KEY_A)) {
-		direction.x = 1;
-	}
+        if (NNE::Systems::InputManager::IsKeyPressed(GLFW_KEY_A)) {
+                direction.x = 1;
+        }
 	
 
-	if (NNE::InputManager::IsKeyPressed(GLFW_KEY_D)) {
-		direction.x = -1;
-	}
+        if (NNE::Systems::InputManager::IsKeyPressed(GLFW_KEY_D)) {
+                direction.x = -1;
+        }
 	
 
-	if (NNE::InputManager::IsKeyPressed(GLFW_KEY_SPACE)) {
-		direction.y = 1;
-	}
+        if (NNE::Systems::InputManager::IsKeyPressed(GLFW_KEY_SPACE)) {
+                direction.y = 1;
+        }
 
 	direction.y += (gravity / speed);
 	
-	_entity->GetComponent<NNE::RigidbodyComponent>()->SetLinearVelocity(direction * speed);	
+        _entity->GetComponent<NNE::Component::Physics::RigidbodyComponent>()->SetLinearVelocity(direction * speed);
 	std::cout << _entity->transform->position.x << std::endl;
 }
 
-void PlayerController::OnHit(NNE::ColliderComponent* other)
+void PlayerController::OnHit(NNE::Component::Physics::ColliderComponent* other)
 {
 	std::cout << "OnHit" << std::endl;
 }

--- a/src/include/AComponent.h
+++ b/src/include/AComponent.h
@@ -1,26 +1,27 @@
 #pragma once
 
-namespace NNE {
-	class AEntity;
-	class AComponent
-	{
-	protected:
-		int _id;
-		AEntity* _entity;
+namespace NNE { class AEntity; }
 
-	public:
-		AComponent();
-		~AComponent() = default;
-		
-		virtual void Awake();
-		virtual void Start();
-		virtual void Update(float deltaTime);
-		virtual void LateUpdate(float deltaTime);
+namespace NNE::Component {
+        class AComponent
+        {
+        protected:
+                int _id;
+                NNE::AEntity* _entity;
 
-		int GetID();
-		AEntity* GetEntity();
-		void SetEntity(AEntity* entity);
-	};
+        public:
+                AComponent();
+                ~AComponent() = default;
+
+                virtual void Awake();
+                virtual void Start();
+                virtual void Update(float deltaTime);
+                virtual void LateUpdate(float deltaTime);
+
+                int GetID();
+                NNE::AEntity* GetEntity();
+                void SetEntity(NNE::AEntity* entity);
+        };
 }
 
 

--- a/src/include/AEntity.h
+++ b/src/include/AEntity.h
@@ -3,21 +3,20 @@
 #include <vector>
 #include <string>
 #include "AComponent.h"
-#include <TransformComponent.h>
+#include "TransformComponent.h"
 
-namespace NNE {	
-	class AComponent;	
-	class AEntity
-	{
-	protected: 
-		int _ID;
-		std::string _Name;	
+namespace NNE {
+        class AEntity
+        {
+        protected:
+                int _ID;
+                std::string _Name;
 
-	public:
-		AEntity();
-		~AEntity();
-		NNE::TransformComponent* transform;
-		std::vector<AComponent*> components;
+        public:
+                AEntity();
+                ~AEntity();
+                NNE::Component::TransformComponent* transform;
+                std::vector<NNE::Component::AComponent*> components;
 
 		int GetID();
 		std::string GetName();
@@ -38,39 +37,39 @@ namespace NNE {
 
 	};
 
-	template<typename T, typename... Args>
-	T* NNE::AEntity::AddComponent(Args&&... args)
-	{
-		T* component = new T(std::forward<Args>(args)...);
-		components.push_back(component);
-		component->SetEntity(this);
-		return component;
-	}
+        template<typename T, typename... Args>
+        T* NNE::AEntity::AddComponent(Args&&... args)
+        {
+                T* component = new T(std::forward<Args>(args)...);
+                components.push_back(component);
+                component->SetEntity(this);
+                return component;
+        }
 
-	template<typename T>
-	T* NNE::AEntity::GetComponent()
-	{
-		for (AComponent* component : components) {
-			T* casted = dynamic_cast<T*>(component);
-			if (casted) {
-				return casted;
-			}
-		}
-		return nullptr;
-	}
+        template<typename T>
+        T* NNE::AEntity::GetComponent()
+        {
+                for (NNE::Component::AComponent* component : components) {
+                        T* casted = dynamic_cast<T*>(component);
+                        if (casted) {
+                                return casted;
+                        }
+                }
+                return nullptr;
+        }
 
-	template<typename T>
-	std::vector<T*> NNE::AEntity::GetComponents()
-	{
-		std::vector<T*> ref;
-		for (AComponent* component : components) {
-			T* casted = dynamic_cast<T*>(component);
-			if (casted) {
-				ref.push_back(casted);
-			}
-		}
-		return ref;
-	}
+        template<typename T>
+        std::vector<T*> NNE::AEntity::GetComponents()
+        {
+                std::vector<T*> ref;
+                for (NNE::Component::AComponent* component : components) {
+                        T* casted = dynamic_cast<T*>(component);
+                        if (casted) {
+                                ref.push_back(casted);
+                        }
+                }
+                return ref;
+        }
 }
 
 

--- a/src/include/Application.h
+++ b/src/include/Application.h
@@ -14,20 +14,18 @@
 #include "RigidbodyComponent.h"
 #include "InputManager.h"
 
-namespace NNE {
-	class VulkanManager;
-	class ColliderComponent;
-	class Application
-	{
-	protected:
+namespace NNE::Systems {
+        class Application
+        {
+        protected:
 
-		std::map<int, int> _link;
-		static Application* Instance;
-		/*GLFWwindow* window;*/
-		float delta;
-		float GetDeltaTime();
+                std::map<int, int> _link;
+                static Application* Instance;
+                /*GLFWwindow* window;*/
+                float delta;
+                float GetDeltaTime();
 
-		static int _genericID;
+                static int _genericID;
 
 		
 
@@ -37,13 +35,13 @@ namespace NNE {
 
 	public:
 		const uint32_t WIDTH = 960;
-		const uint32_t HEIGHT = 540;
-		static Application* GetInstance();
-		Application();
-		~Application();
-		NNE::VulkanManager* VKManager;
-		NNE::PhysicsManager* physicsManager;
-		std::vector<AEntity*> _entities;
+                const uint32_t HEIGHT = 540;
+                static Application* GetInstance();
+                Application();
+                ~Application();
+                NNE::Systems::VulkanManager* VKManager;
+                NNE::Systems::PhysicsManager* physicsManager;
+                std::vector<NNE::AEntity*> _entities;
 
 		void Init();
 		void Update();
@@ -52,23 +50,23 @@ namespace NNE {
 
 		int GenerateID();
 
-		AEntity* CreateEntity();
+                NNE::AEntity* CreateEntity();
 
-		std::unordered_map<JPH::BodyID, ColliderComponent*> colliderMap;
+                std::unordered_map<JPH::BodyID, NNE::Component::Physics::ColliderComponent*> colliderMap;
 
-		void RegisterCollider(JPH::BodyID id, ColliderComponent* collider) {
-			colliderMap[id] = collider;
-		}
+                void RegisterCollider(JPH::BodyID id, NNE::Component::Physics::ColliderComponent* collider) {
+                        colliderMap[id] = collider;
+                }
 
-		ColliderComponent* GetCollider(JPH::BodyID id) {
-			auto it = colliderMap.find(id);
-			return it != colliderMap.end() ? it->second : nullptr;
-		}
+                NNE::Component::Physics::ColliderComponent* GetCollider(JPH::BodyID id) {
+                        auto it = colliderMap.find(id);
+                        return it != colliderMap.end() ? it->second : nullptr;
+                }
 
-		void UnregisterCollider(JPH::BodyID id) {
-			colliderMap.erase(id);
-		}
-	};
+                void UnregisterCollider(JPH::BodyID id) {
+                        colliderMap.erase(id);
+                }
+        };
 }
 
 

--- a/src/include/BoxColliderComponent.h
+++ b/src/include/BoxColliderComponent.h
@@ -3,7 +3,7 @@
 #include <glm/glm.hpp>
 #include <Jolt/Physics/Collision/Shape/BoxShape.h>
 
-namespace NNE
+namespace NNE::Component::Physics
 {
     class BoxColliderComponent : public ColliderComponent
     {

--- a/src/include/CameraComponent.h
+++ b/src/include/CameraComponent.h
@@ -5,8 +5,8 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include "AEntity.h"
 
-namespace NNE {    
-    class CameraComponent : public AComponent {
+namespace NNE::Component::Render {
+    class CameraComponent : public NNE::Component::AComponent {
     private:
         glm::mat4 viewMatrix;
         glm::mat4 projectionMatrix;
@@ -16,17 +16,16 @@ namespace NNE {
         float farPlane;
 
     public:
-        CameraComponent(float fov = 45.0f, float aspectRatio = 16.0f / 9.0f, float nearPlane = 0.1f, float farPlane = 100.0f);
+        CameraComponent(float fov = 45.0f, float aspectRatio = 16.0f/9.0f, float nearPlane = 0.1f, float farPlane = 100.0f);
         virtual void Update(float deltaTime) override;
         void SetPerspective(float fov, float aspectRatio, float nearPlane, float farPlane);
         void UpdateViewMatrix(const glm::vec3& position, const glm::vec3& target, const glm::vec3& up);
 
         glm::mat4 GetViewMatrix() const { return viewMatrix; }
         glm::mat4 GetProjectionMatrix() const { return projectionMatrix; }
-		float GetFOV() { return fov; }
-		float GetAspectRatio() { return aspectRatio; }
-		float GetNearPlane() { return nearPlane; }
-		float GetFarPlane() { return farPlane; }
-
+        float GetFOV() { return fov; }
+        float GetAspectRatio() { return aspectRatio; }
+        float GetNearPlane() { return nearPlane; }
+        float GetFarPlane() { return farPlane; }
     };
 }

--- a/src/include/ColliderComponent.h
+++ b/src/include/ColliderComponent.h
@@ -4,9 +4,9 @@
 #include <Jolt/Jolt.h>
 #include <Jolt/Physics/Collision/Shape/Shape.h>
 
-namespace NNE
+namespace NNE::Component::Physics
 {
-    class ColliderComponent : public AComponent
+    class ColliderComponent : public NNE::Component::AComponent
     {
     protected:
         JPH::ShapeRefC shape;

--- a/src/include/InputManager.h
+++ b/src/include/InputManager.h
@@ -5,12 +5,12 @@
 #include <glm/glm.hpp>
 #include <unordered_map>
 
-namespace NNE {
+namespace NNE::Systems {
 
     class InputManager {
     public:
         static void Init(GLFWwindow* win);
-        static void Update();  // Met à jour les états des touches
+        static void Update();
         static bool IsKeyPressed(int key);
         static bool IsKeyJustPressed(int key);
         static bool IsKeyJustReleased(int key);

--- a/src/include/MeshComponent.h
+++ b/src/include/MeshComponent.h
@@ -1,12 +1,11 @@
 #pragma once
-#include "AComponent.h" 
+#include "AComponent.h"
 #include <string>
 #include <vulkan/vulkan.h>
 
-namespace NNE {
-    class AComponent;
-	class MeshComponent : public AComponent
-	{
+namespace NNE::Component::Render {
+        class MeshComponent : public NNE::Component::AComponent
+        {
     private:
         std::string modelPath;
         std::string texturePath;
@@ -14,18 +13,12 @@ namespace NNE {
         uint32_t indexCount = 0;
 
     public:
-        MeshComponent();   
+        MeshComponent();
 
-        // Ajout des ressources Vulkan propres à chaque entité
         VkImage textureImage = VK_NULL_HANDLE;
         VkDeviceMemory textureImageMemory = VK_NULL_HANDLE;
         VkImageView textureImageView = VK_NULL_HANDLE;
         VkSampler textureSampler = VK_NULL_HANDLE;
-
-        /*virtual void Awake() override;
-        virtual void Start() override;
-        virtual void Update(float deltaTime) override;
-        virtual void LateUpdate(float deltaTime) override;*/
 
         std::string GetModelPath() const;
         std::string GetTexturePath() const;
@@ -36,7 +29,5 @@ namespace NNE {
         void setIndexCount(uint32_t count) { indexCount = count; }
         uint32_t getIndexOffset() const { return indexOffset; }
         uint32_t getIndexCount() const { return indexCount; }
-	};
+        };
 }
-	
-

--- a/src/include/MonoComponent.h
+++ b/src/include/MonoComponent.h
@@ -1,20 +1,20 @@
 #pragma once
 #include "AComponent.h"
-//#include "ColliderComponent.h"
 
-namespace NNE {	
-	class ColliderComponent;
-	class MonoComponent : public AComponent
-	{
-	public:
-		virtual void Awake() override;
-		virtual void Start() override;
-		virtual void Update(float deltaTime) override;
-		virtual void LateUpdate(float deltaTime) override;
+namespace NNE::Component::Physics { class ColliderComponent; }
 
-		virtual void OnHit(NNE::ColliderComponent* other);
-		virtual void OnTriggerHit(NNE::ColliderComponent* other);
-	};
+namespace NNE::Component {
+        class MonoComponent : public AComponent
+        {
+        public:
+                virtual void Awake() override;
+                virtual void Start() override;
+                virtual void Update(float deltaTime) override;
+                virtual void LateUpdate(float deltaTime) override;
+
+                virtual void OnHit(NNE::Component::Physics::ColliderComponent* other);
+                virtual void OnTriggerHit(NNE::Component::Physics::ColliderComponent* other);
+        };
 }
 
 

--- a/src/include/PhysicsManager.h
+++ b/src/include/PhysicsManager.h
@@ -5,7 +5,7 @@
 #include <Jolt/Physics/PhysicsSystem.h>
 #include <Jolt/RegisterTypes.h>
 
-namespace NNE {
+namespace NNE::Systems {
 
     class PhysicsManager {
     private:

--- a/src/include/PlaneCollider.h
+++ b/src/include/PlaneCollider.h
@@ -3,20 +3,19 @@
 #include <glm/glm.hpp>
 #include <Jolt/Physics/Collision/Shape/PlaneShape.h>
 
-namespace NNE
+namespace NNE::Component::Physics
 {
-	class ColliderComponent;
-	class PlaneCollider : public ColliderComponent
-	{
-	private:
-		glm::vec3 normal;
-		float distance;	
-		JPH::Plane plane;
+        class PlaneCollider : public ColliderComponent
+        {
+        private:
+                glm::vec3 normal;
+                float distance;
+                JPH::Plane plane;
 
-	public:
-		PlaneCollider(const glm::vec3& normal, float distance);
-		void CreateShape() override;
-	};
+        public:
+                PlaneCollider(const glm::vec3& normal, float distance);
+                void CreateShape() override;
+        };
 }
 
 

--- a/src/include/RigidbodyComponent.h
+++ b/src/include/RigidbodyComponent.h
@@ -7,9 +7,9 @@
 #include <Jolt/Physics/Body/BodyID.h>
 #include <glm/glm.hpp>
 
-namespace NNE {
+namespace NNE::Component::Physics {
 
-    class RigidbodyComponent : public AComponent {
+    class RigidbodyComponent : public NNE::Component::AComponent {
     private:
         JPH::BodyID bodyID;
         float mass;
@@ -24,7 +24,7 @@ namespace NNE {
         JPH::BodyID GetBodyID() const;
 
         void SetLinearVelocity(glm::vec3 velocity);
-		glm::vec3 GetLinearVelocity() const;
+        glm::vec3 GetLinearVelocity() const;
     };
 
 }

--- a/src/include/TransformComponent.h
+++ b/src/include/TransformComponent.h
@@ -5,8 +5,8 @@
 #include <iostream>
 #include <vector>
 
-namespace NNE {
-	class alignas(16) TransformComponent : public AComponent
+namespace NNE::Component {
+        class alignas(16) TransformComponent : public AComponent
 	{
 	public:
 		alignas(16) glm::vec3 position;

--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -38,10 +38,10 @@
 
 
 
-namespace NNE {
-	class AEntity;	
+namespace NNE { class AEntity; }
 
-	struct QueueFamilyIndices {
+namespace NNE::Systems {
+        struct QueueFamilyIndices {
 		std::optional<uint32_t> graphicsFamily;
 		std::optional<uint32_t> presentFamily;
 
@@ -100,12 +100,12 @@ namespace NNE {
 		alignas(16) glm::mat4 model;		
 	};	
 
-	struct GlobalUniformBufferObject {
-		alignas(16)glm::mat4 view;
-		alignas(16)glm::mat4 proj;
-	};
+        struct GlobalUniformBufferObject {
+                alignas(16)glm::mat4 view;
+                alignas(16)glm::mat4 proj;
+        };
 
-	class VulkanManager
+        class VulkanManager
 	{
 	protected:
 		size_t dynamicAlignment;
@@ -176,7 +176,7 @@ namespace NNE {
 		VkSampleCountFlagBits msaaSamples = VK_SAMPLE_COUNT_1_BIT;
 
 	public :
-		CameraComponent* activeCamera = nullptr;
+            NNE::Component::Render::CameraComponent* activeCamera = nullptr;
 		VkInstance instance = VK_NULL_HANDLE;
 		GLFWwindow* window;
 		VulkanManager();
@@ -260,13 +260,13 @@ namespace NNE {
 }
 
 namespace std {
-	template<> struct hash<NNE::Vertex> {
-		size_t operator()(NNE::Vertex const& vertex) const {
-			return ((hash<glm::vec3>()(vertex.pos) ^
-				(hash<glm::vec3>()(vertex.color) << 1)) >> 1) ^
-				(hash<glm::vec2>()(vertex.texCoord) << 1);
-		}
-	};
+        template<> struct hash<NNE::Systems::Vertex> {
+                size_t operator()(NNE::Systems::Vertex const& vertex) const {
+                        return ((hash<glm::vec3>()(vertex.pos) ^
+                                (hash<glm::vec3>()(vertex.color) << 1)) >> 1) ^
+                                (hash<glm::vec2>()(vertex.texCoord) << 1);
+                }
+        };
 }
 
 

--- a/src/src/AComponent.cpp
+++ b/src/src/AComponent.cpp
@@ -1,38 +1,38 @@
 #include "AComponent.h"
-#include <Application.h>
+#include "Application.h"
 
-NNE::AComponent::AComponent()
+NNE::Component::AComponent::AComponent()
 {
-	_id = NNE::Application::GetInstance()->GenerateID();
+        _id = NNE::Systems::Application::GetInstance()->GenerateID();
 }
 
-void NNE::AComponent::Awake()
-{
-}
-
-void NNE::AComponent::Start()
+void NNE::Component::AComponent::Awake()
 {
 }
 
-void NNE::AComponent::Update(float deltaTime)
+void NNE::Component::AComponent::Start()
 {
 }
 
-void NNE::AComponent::LateUpdate(float deltaTime)
+void NNE::Component::AComponent::Update(float deltaTime)
 {
 }
 
-int NNE::AComponent::GetID()
+void NNE::Component::AComponent::LateUpdate(float deltaTime)
 {
-	return _id;
 }
 
-NNE::AEntity* NNE::AComponent::GetEntity()
+int NNE::Component::AComponent::GetID()
 {
-	return _entity;
+        return _id;
 }
 
-void NNE::AComponent::SetEntity(AEntity* entity)
+NNE::AEntity* NNE::Component::AComponent::GetEntity()
 {
-	_entity = entity;
+        return _entity;
+}
+
+void NNE::Component::AComponent::SetEntity(NNE::AEntity* entity)
+{
+        _entity = entity;
 }

--- a/src/src/AEntity.cpp
+++ b/src/src/AEntity.cpp
@@ -1,19 +1,19 @@
 #include "AEntity.h"
-#include <Application.h>
+#include "Application.h"
 
 
 NNE::AEntity::AEntity()
 {
-	_ID = NNE::Application::GetInstance()->GenerateID();
-	transform = this->AddComponent<TransformComponent>();
+        _ID = NNE::Systems::Application::GetInstance()->GenerateID();
+        transform = this->AddComponent<NNE::Component::TransformComponent>();
 }
 
 NNE::AEntity::~AEntity()
 {
-	for (AComponent* comp : NNE::AEntity::components) {
-		delete comp;
-	}
-	components.clear();
+        for (NNE::Component::AComponent* comp : NNE::AEntity::components) {
+                delete comp;
+        }
+        components.clear();
 }
 
 int NNE::AEntity::GetID()
@@ -24,36 +24,36 @@ int NNE::AEntity::GetID()
 
 void NNE::AEntity::Awake()
 {
-	if (!components.empty()) {
-		for (AComponent* component : components) {
-			component->Awake();
-		}
-	}
+        if (!components.empty()) {
+                for (NNE::Component::AComponent* component : components) {
+                        component->Awake();
+                }
+        }
 }
 
 void NNE::AEntity::Start()
 {
-	if (!components.empty()) {
-		for (AComponent* component : components) {
-			component->Start();
-		}
-	}
+        if (!components.empty()) {
+                for (NNE::Component::AComponent* component : components) {
+                        component->Start();
+                }
+        }
 }
 
 void NNE::AEntity::Update(float delta)
 {
-	if (!components.empty()) {
-		for (AComponent* component : components) {
-			component->Update(delta);
-		}
-	}
+        if (!components.empty()) {
+                for (NNE::Component::AComponent* component : components) {
+                        component->Update(delta);
+                }
+        }
 }
 
 void NNE::AEntity::LateUpdate(float delta)
 {
-	if (!components.empty()) {
-		for (AComponent* component : components) {
-			component->LateUpdate(delta);
-		}
-	}
+        if (!components.empty()) {
+                for (NNE::Component::AComponent* component : components) {
+                        component->LateUpdate(delta);
+                }
+        }
 }

--- a/src/src/AScene.cpp
+++ b/src/src/AScene.cpp
@@ -38,16 +38,16 @@ bool AScene::Save(const std::string& path) const
         file << "    {\n      \"components\": [\n";
 
         bool first = true;
-        for (AComponent* comp : entity->components) {
+        for (NNE::Component::AComponent* comp : entity->components) {
             if (!first) file << ",\n";
             first = false;
 
-            if (auto* t = dynamic_cast<TransformComponent*>(comp)) {
+            if (auto* t = dynamic_cast<NNE::Component::TransformComponent*>(comp)) {
                 file << "        {\"type\":\"TransformComponent\",";
                 file << "\"position\":"; WriteVec3(file, t->position); file << ",";
                 file << "\"rotation\":"; WriteVec3(file, t->rotation); file << ",";
                 file << "\"scale\":"; WriteVec3(file, t->scale); file << "}";
-            } else if (auto* m = dynamic_cast<MeshComponent*>(comp)) {
+            } else if (auto* m = dynamic_cast<NNE::Component::Render::MeshComponent*>(comp)) {
                 file << "        {\"type\":\"MeshComponent\",";
                 file << "\"model\":\"" << m->GetModelPath() << "\",";
                 file << "\"texture\":\"" << m->GetTexturePath() << "\"}";
@@ -69,7 +69,6 @@ bool AScene::Load(const std::string& path)
     if (!file.is_open())
         return false;
 
-    // Clear previous entities
     for (AEntity* e : entities)
         delete e;
     entities.clear();
@@ -111,7 +110,7 @@ bool AScene::Load(const std::string& path)
                 size_t sEnd = content.find(']', sBegin);
                 glm::vec3 s = ParseVec3(content.substr(sBegin, sEnd - sBegin + 1));
 
-                TransformComponent* t = entity->AddComponent<TransformComponent>();
+                NNE::Component::TransformComponent* t = entity->AddComponent<NNE::Component::TransformComponent>();
                 t->position = p;
                 t->rotation = r;
                 t->scale = s;
@@ -125,7 +124,7 @@ bool AScene::Load(const std::string& path)
                 size_t tEnd = content.find('"', tBegin + 1);
                 std::string texture = content.substr(tBegin + 1, tEnd - tBegin - 1);
 
-                MeshComponent* m = entity->AddComponent<MeshComponent>();
+                NNE::Component::Render::MeshComponent* m = entity->AddComponent<NNE::Component::Render::MeshComponent>();
                 m->SetModelPath(model);
                 m->SetTexturePath(texture);
                 pos = tEnd + 1;

--- a/src/src/Application.cpp
+++ b/src/src/Application.cpp
@@ -1,21 +1,18 @@
 #include "Application.h"
 
-
 std::clock_t lastFrameTime;
-NNE::Application* NNE::Application::Instance = nullptr;
-int NNE::Application::_genericID = 0;
+NNE::Systems::Application* NNE::Systems::Application::Instance = nullptr;
+int NNE::Systems::Application::_genericID = 0;
 
-
-
-NNE::Application::Application()
+NNE::Systems::Application::Application()
 {
     Instance = this;
     VKManager = new VulkanManager();
-	physicsManager = new PhysicsManager();
+    physicsManager = new PhysicsManager();
     delta = 0;
 }
 
-NNE::Application::~Application()
+NNE::Systems::Application::~Application()
 {
     if (VKManager) {
         VKManager->CleanUp();
@@ -23,82 +20,76 @@ NNE::Application::~Application()
         VKManager = nullptr;
     }
 
-
-    for (AEntity* entity : _entities) {
+    for (NNE::AEntity* entity : _entities) {
         delete entity;
-    }   
+    }
     _entities.clear();
 }
 
-
-void NNE::Application::Init()
-{    
-    Open();    
+void NNE::Systems::Application::Init()
+{
+    Open();
     VKManager->initVulkan();
     physicsManager->Initialize();
-    //VKManager->LoadEntitiesModels(_entities);
 
     uint32_t extensionCount = 0;
     vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, nullptr);
 
-    for (AEntity* entity : _entities)
+    for (NNE::AEntity* entity : _entities)
     {
         entity->Awake();
         entity->Start();
     }
 }
 
-void NNE::Application::Update()
+void NNE::Systems::Application::Update()
 {
-    
     while (!glfwWindowShouldClose(VKManager->window)) {
         delta = GetDeltaTime();
-        glfwPollEvents();        
-        InputManager::Update();
-        physicsManager->Update(delta);       
+        glfwPollEvents();
+        NNE::Systems::InputManager::Update();
+        physicsManager->Update(delta);
 
-        //Update
-        for(AEntity* entity : _entities)
+        for (NNE::AEntity* entity : _entities)
         {
             entity->Update(delta);
         }
 
-        //LateUpdate
-        for (AEntity* entity : _entities)
+        for (NNE::AEntity* entity : _entities)
         {
             entity->LateUpdate(delta);
         }
 
         VKManager->drawFrame();
-    }   
+    }
     vkDeviceWaitIdle(VKManager->device);
 }
 
-void NNE::Application::Open()
+void NNE::Systems::Application::Open()
 {
     VKManager->CreateGLFWWindow(WIDTH, HEIGHT);
-    InputManager::Init(VKManager->window);
+    NNE::Systems::InputManager::Init(VKManager->window);
 }
 
-void NNE::Application::Quit()
-{    
+void NNE::Systems::Application::Quit()
+{
     glfwTerminate();
 }
 
-int NNE::Application::GenerateID()
+int NNE::Systems::Application::GenerateID()
 {
     _genericID++;
     return _genericID;
 }
 
-NNE::AEntity* NNE::Application::CreateEntity()
+NNE::AEntity* NNE::Systems::Application::CreateEntity()
 {
-    AEntity* entity = new AEntity();
+    NNE::AEntity* entity = new NNE::AEntity();
     _entities.push_back(entity);
     return entity;
 }
 
-float NNE::Application::GetDeltaTime()
+float NNE::Systems::Application::GetDeltaTime()
 {
     static auto lastFrame = std::chrono::high_resolution_clock::now();
     auto currentFrame = std::chrono::high_resolution_clock::now();
@@ -107,15 +98,7 @@ float NNE::Application::GetDeltaTime()
     return dt;
 }
 
-//GLFWwindow* NNE::Application::CreateGLFWWindow(int width, int height)
-//{
-//    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-//    glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
-//    window = glfwCreateWindow(width, height, "Vulkan window", nullptr, nullptr);
-//    return window;
-//}
-
-NNE::Application* NNE::Application::GetInstance()
+NNE::Systems::Application* NNE::Systems::Application::GetInstance()
 {
     return Instance;
 }

--- a/src/src/BoxColliderComponent.cpp
+++ b/src/src/BoxColliderComponent.cpp
@@ -1,35 +1,24 @@
 #include "BoxColliderComponent.h"
 #include <Jolt/Physics/Collision/Shape/BoxShape.h>
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
-#include <Application.h>
+#include "Application.h"
 
-NNE::BoxColliderComponent::BoxColliderComponent(const glm::vec3& size) : size(size)
+NNE::Component::Physics::BoxColliderComponent::BoxColliderComponent(const glm::vec3& size) : size(size)
 {
-	
 }
 
-void NNE::BoxColliderComponent::Awake()
+void NNE::Component::Physics::BoxColliderComponent::Awake()
 {
-	CreateShape();  // Maintenant le système physique est prêt
+        CreateShape();
 }
 
-void NNE::BoxColliderComponent::CreateShape()
+void NNE::Component::Physics::BoxColliderComponent::CreateShape()
 {
-	shape = new JPH::BoxShape(JPH::Vec3(size.x, size.y, size.z));
+        shape = new JPH::BoxShape(JPH::Vec3(size.x, size.y, size.z));
 
-	JPH::BodyCreationSettings bodySettings(shape, JPH::RVec3::sZero(), JPH::Quat::sIdentity(), JPH::EMotionType::Dynamic, 0);
-	auto& bodyInterface = NNE::Application::GetInstance()->physicsManager->GetPhysicsSystem()->GetBodyInterface();
-	bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
+        JPH::BodyCreationSettings bodySettings(shape, JPH::RVec3::sZero(), JPH::Quat::sIdentity(), JPH::EMotionType::Dynamic, 0);
+        auto& bodyInterface = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem()->GetBodyInterface();
+        bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
 
-	Application::GetInstance()->RegisterCollider(bodyID, this);
+        NNE::Systems::Application::GetInstance()->RegisterCollider(bodyID, this);
 }
-
-//void NNE::BoxColliderComponent::OnHit(ColliderComponent* other)
-//{
-//	std::cout << "Collision avec : " << typeid(*other).name() << std::endl;
-//}
-//
-//void NNE::BoxColliderComponent::OnTriggerHit(ColliderComponent* other)
-//{
-//	std::cout << "Trigger avec : " << typeid(*other).name() << std::endl;
-//}

--- a/src/src/CameraComponent.cpp
+++ b/src/src/CameraComponent.cpp
@@ -1,15 +1,14 @@
 #include "CameraComponent.h"
 
-NNE::CameraComponent::CameraComponent(float fov, float aspectRatio, float nearPlane, float farPlane) : fov(fov), aspectRatio(aspectRatio), nearPlane(nearPlane), farPlane(farPlane)
+NNE::Component::Render::CameraComponent::CameraComponent(float fov, float aspectRatio, float nearPlane, float farPlane) : fov(fov), aspectRatio(aspectRatio), nearPlane(nearPlane), farPlane(farPlane)
 {
-	SetPerspective(fov, aspectRatio, nearPlane, farPlane);
+        SetPerspective(fov, aspectRatio, nearPlane, farPlane);
 }
 
-void NNE::CameraComponent::Update(float deltaTime)
+void NNE::Component::Render::CameraComponent::Update(float deltaTime)
 {
-    CameraComponent* cameraComp = _entity->GetComponent<CameraComponent>();
-    TransformComponent* transform = _entity->GetComponent<TransformComponent>();
-    // S’il s’agit d’une entité “caméra”
+    auto* cameraComp = _entity->GetComponent<NNE::Component::Render::CameraComponent>();
+    auto* transform = _entity->GetComponent<NNE::Component::TransformComponent>();
     if (cameraComp && transform) {
         glm::vec3 pos = transform->GetWorldPosition();
         glm::vec3 target = pos + transform->GetForward();
@@ -18,7 +17,7 @@ void NNE::CameraComponent::Update(float deltaTime)
     }
 }
 
-void NNE::CameraComponent::SetPerspective(float fov, float aspectRatio, float nearPlane, float farPlane)
+void NNE::Component::Render::CameraComponent::SetPerspective(float fov, float aspectRatio, float nearPlane, float farPlane)
 {
     this->fov = fov;
     this->aspectRatio = aspectRatio;
@@ -26,10 +25,10 @@ void NNE::CameraComponent::SetPerspective(float fov, float aspectRatio, float ne
     this->farPlane = farPlane;
 
     projectionMatrix = glm::perspective(glm::radians(fov), aspectRatio, nearPlane, farPlane);
-    projectionMatrix[1][1] *= -1; // Correction pour Vulkan
+    projectionMatrix[1][1] *= -1;
 }
 
-void NNE::CameraComponent::UpdateViewMatrix(const glm::vec3& position, const glm::vec3& target, const glm::vec3& up)
+void NNE::Component::Render::CameraComponent::UpdateViewMatrix(const glm::vec3& position, const glm::vec3& target, const glm::vec3& up)
 {
     viewMatrix = glm::lookAt(position, target, up);
 }

--- a/src/src/ColliderComponent.cpp
+++ b/src/src/ColliderComponent.cpp
@@ -1,28 +1,28 @@
 #include "ColliderComponent.h"
-#include <MonoComponent.h>
+#include "MonoComponent.h"
 
 
-void NNE::ColliderComponent::OnHit(ColliderComponent* other)
+void NNE::Component::Physics::ColliderComponent::OnHit(ColliderComponent* other)
 {
-	std::vector<MonoComponent*> list = _entity->GetComponents<MonoComponent>();
+        std::vector<NNE::Component::MonoComponent*> list = _entity->GetComponents<NNE::Component::MonoComponent>();
 
 	if (!list.empty()) {
-		for each (MonoComponent * comp in list)
-		{
-			comp->OnHit(other);
-		}
+                for each (NNE::Component::MonoComponent * comp in list)
+                {
+                        comp->OnHit(other);
+                }
 	}
 	
 }
 
-void NNE::ColliderComponent::OnTriggerHit(ColliderComponent* other)
+void NNE::Component::Physics::ColliderComponent::OnTriggerHit(ColliderComponent* other)
 {
-	std::vector<MonoComponent*> list = _entity->GetComponents<MonoComponent>();
+        std::vector<NNE::Component::MonoComponent*> list = _entity->GetComponents<NNE::Component::MonoComponent>();
 
 	if (!list.empty()) {
-		for each (MonoComponent * comp in list)
-		{
-			comp->OnTriggerHit(other);
-		}
+                for each (NNE::Component::MonoComponent * comp in list)
+                {
+                        comp->OnTriggerHit(other);
+                }
 	}
 }

--- a/src/src/InputManager.cpp
+++ b/src/src/InputManager.cpp
@@ -1,41 +1,38 @@
 #include "InputManager.h"
 
-namespace NNE {
+namespace NNE::Systems {
 
-    void InputManager::Init(GLFWwindow* win) {
-        window = win;
-    }
-
-    void InputManager::Update() {
-        // Copier l'état précédent des touches
-        previousKeys = currentKeys;
-
-        // Met à jour l'état actuel des touches
-        for (int key = GLFW_KEY_SPACE; key <= GLFW_KEY_LAST; ++key) {
-            currentKeys[key] = glfwGetKey(window, key) == GLFW_PRESS;
-        }
-    }
-
-    bool InputManager::IsKeyPressed(int key) {
-        return currentKeys[key];
-    }
-
-    bool InputManager::IsKeyJustPressed(int key) {
-        return currentKeys[key] && !previousKeys[key];
-    }
-
-    bool InputManager::IsKeyJustReleased(int key) {
-        return !currentKeys[key] && previousKeys[key];
-    }
-
-    glm::vec2 InputManager::GetMousePosition() {
-        double x, y;
-        glfwGetCursorPos(window, &x, &y);
-        return glm::vec2(x, y);
-    }
-
-    bool InputManager::IsMouseButtonPressed(int button) {
-        return glfwGetMouseButton(window, button) == GLFW_PRESS;
-    }
-
+void InputManager::Init(GLFWwindow* win) {
+    window = win;
 }
+
+void InputManager::Update() {
+    previousKeys = currentKeys;
+    for (int key = GLFW_KEY_SPACE; key <= GLFW_KEY_LAST; ++key) {
+        currentKeys[key] = glfwGetKey(window, key) == GLFW_PRESS;
+    }
+}
+
+bool InputManager::IsKeyPressed(int key) {
+    return currentKeys[key];
+}
+
+bool InputManager::IsKeyJustPressed(int key) {
+    return currentKeys[key] && !previousKeys[key];
+}
+
+bool InputManager::IsKeyJustReleased(int key) {
+    return !currentKeys[key] && previousKeys[key];
+}
+
+glm::vec2 InputManager::GetMousePosition() {
+    double x, y;
+    glfwGetCursorPos(window, &x, &y);
+    return glm::vec2(x, y);
+}
+
+bool InputManager::IsMouseButtonPressed(int button) {
+    return glfwGetMouseButton(window, button) == GLFW_PRESS;
+}
+
+} // namespace NNE::Systems

--- a/src/src/MeshComponent.cpp
+++ b/src/src/MeshComponent.cpp
@@ -1,7 +1,7 @@
 #include "MeshComponent.h"
 #include <iostream>
 
-NNE::MeshComponent::MeshComponent()
+NNE::Component::Render::MeshComponent::MeshComponent()
 {
     textureImage = VK_NULL_HANDLE;
     textureImageMemory = VK_NULL_HANDLE;
@@ -9,21 +9,20 @@ NNE::MeshComponent::MeshComponent()
     textureSampler = VK_NULL_HANDLE;
 }
 
-void NNE::MeshComponent::SetModelPath(std::string path)
+void NNE::Component::Render::MeshComponent::SetModelPath(std::string path)
 {
-	modelPath = path;
+        modelPath = std::move(path);
 }
 
-void NNE::MeshComponent::SetTexturePath(std::string path)
+void NNE::Component::Render::MeshComponent::SetTexturePath(std::string path)
 {
-	texturePath = path;
+        texturePath = std::move(path);
 }
 
-std::string NNE::MeshComponent::GetModelPath() const {
+std::string NNE::Component::Render::MeshComponent::GetModelPath() const {
     return modelPath;
 }
 
-std::string NNE::MeshComponent::GetTexturePath() const {
-	//std::cout << "Texture path: " << texturePath << std::endl;
+std::string NNE::Component::Render::MeshComponent::GetTexturePath() const {
     return texturePath;
 }

--- a/src/src/MonoComponent.cpp
+++ b/src/src/MonoComponent.cpp
@@ -1,26 +1,26 @@
 #include "MonoComponent.h"
 
-void NNE::MonoComponent::Awake()
+void NNE::Component::MonoComponent::Awake()
 {
 
 }
 
-void NNE::MonoComponent::Start()
+void NNE::Component::MonoComponent::Start()
 {
 }
 
-void NNE::MonoComponent::Update(float deltaTime)
+void NNE::Component::MonoComponent::Update(float deltaTime)
 {
 }
 
-void NNE::MonoComponent::LateUpdate(float deltaTime)
+void NNE::Component::MonoComponent::LateUpdate(float deltaTime)
 {
 }
 
-void NNE::MonoComponent::OnHit(NNE::ColliderComponent* other)
+void NNE::Component::MonoComponent::OnHit(NNE::Component::Physics::ColliderComponent* other)
 {
 }
 
-void NNE::MonoComponent::OnTriggerHit(NNE::ColliderComponent* other)
+void NNE::Component::MonoComponent::OnTriggerHit(NNE::Component::Physics::ColliderComponent* other)
 {
 }

--- a/src/src/PlaneCollider.cpp
+++ b/src/src/PlaneCollider.cpp
@@ -1,12 +1,12 @@
 #include "PlaneCollider.h"
-#include <Jolt/Physics/Collision/Shape/PlaneShape.h> 
+#include <Jolt/Physics/Collision/Shape/PlaneShape.h>
 
-NNE::PlaneCollider::PlaneCollider(const glm::vec3& normal, float distance)
+NNE::Component::Physics::PlaneCollider::PlaneCollider(const glm::vec3& normal, float distance)
 {
-	plane = JPH::Plane(JPH::Vec3(normal.x, normal.y, normal.z), distance);
+        plane = JPH::Plane(JPH::Vec3(normal.x, normal.y, normal.z), distance);
 }
 
-void NNE::PlaneCollider::CreateShape()
-{	
-	shape = new JPH::PlaneShape(plane);
+void NNE::Component::Physics::PlaneCollider::CreateShape()
+{
+        shape = new JPH::PlaneShape(plane);
 }

--- a/src/src/RigidbodyComponent.cpp
+++ b/src/src/RigidbodyComponent.cpp
@@ -1,100 +1,79 @@
-﻿#include "RigidbodyComponent.h"
+#include "RigidbodyComponent.h"
 #include "Application.h"
 #include "TransformComponent.h"
-#include <Jolt/Physics/Body/BodyCreationSettings.h> 
+#include <Jolt/Physics/Body/BodyCreationSettings.h>
 
-namespace NNE {
+namespace NNE::Component::Physics {
 
-    RigidbodyComponent::RigidbodyComponent(float mass, bool kinematic)
-        : bodyID(), mass(mass), isKinematic(kinematic) {
-    }
-
-    RigidbodyComponent::~RigidbodyComponent() {
-        auto physicsSystem = Application::GetInstance()->physicsManager->GetPhysicsSystem();
-        if (!bodyID.IsInvalid()) {
-            physicsSystem->GetBodyInterface().RemoveBody(bodyID);
-        }
-    }
-
-    void RigidbodyComponent::Awake() {
-        std::cout << "RigidBodyAwake" << std::endl;
-        auto physicsSystem = Application::GetInstance()->physicsManager->GetPhysicsSystem();
-        auto* transform = GetEntity()->GetComponent<TransformComponent>();
-        auto* collider = GetEntity()->GetComponent<ColliderComponent>();
-
-        if (!collider || !collider->GetShape()) {
-            std::cerr << "ColliderComponent manquant ou invalide sur l'entité." << std::endl;
-            return;
-        }
-
-        
-        JPH::BodyCreationSettings bodySettings(
-            collider->GetShape(),
-            JPH::RVec3(transform->position.x, transform->position.y, transform->position.z),
-            JPH::Quat::sIdentity(),
-            (mass > 0.0f) ? JPH::EMotionType::Dynamic : (isKinematic ? JPH::EMotionType::Kinematic : JPH::EMotionType::Dynamic),
-            0 
-        );
-
-        
-        if (mass > 0.0f) {
-            bodySettings.mMassPropertiesOverride.mMass = mass;
-        }
-
-        
-        JPH::BodyInterface& bodyInterface = physicsSystem->GetBodyInterface();
-        bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
-
-        
-        if (bodyID.IsInvalid()) {
-            std::cerr << "❌ Échec de la création du RigidBody !" << std::endl;
-            return;
-        }
-    }
-
-    void RigidbodyComponent::Update(float deltaTime) {
-        
-        auto physicsSystem = Application::GetInstance()->physicsManager->GetPhysicsSystem();
-        auto& bodyInterface = physicsSystem->GetBodyInterface();
-        //std::cout << bodyID.IsInvalid() << std::endl;
-        if (!bodyID.IsInvalid()) {
-            auto* transform = GetEntity()->GetComponent<TransformComponent>();
-
-            JPH::RVec3 pos = bodyInterface.GetPosition(bodyID);
-            JPH::Quat rot = bodyInterface.GetRotation(bodyID);
-
-            transform->position = glm::vec3(pos.GetX(), pos.GetY(), pos.GetZ());            
-
-            // 🔥 Correction : Convertir le quaternion en Euler angles
-            glm::quat glmQuat(rot.GetW(), rot.GetX(), rot.GetY(), rot.GetZ());
-            glm::vec3 eulerAngles = glm::degrees(glm::eulerAngles(glmQuat));
-
-            transform->rotation = eulerAngles;
-        }
-    }
-
-    JPH::BodyID RigidbodyComponent::GetBodyID() const {
-        return bodyID;
-    }
-
-    void RigidbodyComponent::SetLinearVelocity(glm::vec3 velocity)
-    {
-		auto physicsSystem = Application::GetInstance()->physicsManager->GetPhysicsSystem();
-		auto& bodyInterface = physicsSystem->GetBodyInterface();        
-		if (!bodyID.IsInvalid()) {
-			bodyInterface.SetLinearVelocity(bodyID, JPH::RVec3(velocity.x, velocity.y, velocity.z));            
-		}
-    }
-
-    glm::vec3 RigidbodyComponent::GetLinearVelocity() const
-    {
-		auto physicsSystem = Application::GetInstance()->physicsManager->GetPhysicsSystem();
-		auto& bodyInterface = physicsSystem->GetBodyInterface();
-		if (!bodyID.IsInvalid()) {
-			JPH::RVec3 velocity = bodyInterface.GetLinearVelocity(bodyID);
-			return glm::vec3(velocity.GetX(), velocity.GetY(), velocity.GetZ());
-		}
-        return glm::vec3();
-    }
-
+RigidbodyComponent::RigidbodyComponent(float mass, bool kinematic)
+    : bodyID(), mass(mass), isKinematic(kinematic) {
 }
+
+RigidbodyComponent::~RigidbodyComponent() {
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
+    if (!bodyID.IsInvalid()) {
+        physicsSystem->GetBodyInterface().RemoveBody(bodyID);
+    }
+}
+
+void RigidbodyComponent::Awake() {
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
+    auto* transform = GetEntity()->GetComponent<NNE::Component::TransformComponent>();
+    auto* collider = GetEntity()->GetComponent<NNE::Component::Physics::ColliderComponent>();
+
+    if (!collider || !collider->GetShape()) {
+        return;
+    }
+
+    JPH::BodyCreationSettings bodySettings(
+        collider->GetShape(),
+        JPH::RVec3(transform->position.x, transform->position.y, transform->position.z),
+        JPH::Quat::sIdentity(),
+        (mass > 0.0f) ? JPH::EMotionType::Dynamic : (isKinematic ? JPH::EMotionType::Kinematic : JPH::EMotionType::Dynamic),
+        0);
+
+    if (mass > 0.0f) {
+        bodySettings.mMassPropertiesOverride.mMass = mass;
+    }
+
+    JPH::BodyInterface& bodyInterface = physicsSystem->GetBodyInterface();
+    bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
+}
+
+void RigidbodyComponent::Update(float deltaTime) {
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
+    auto& bodyInterface = physicsSystem->GetBodyInterface();
+    if (!bodyID.IsInvalid()) {
+        auto* transform = GetEntity()->GetComponent<NNE::Component::TransformComponent>();
+        JPH::RVec3 pos = bodyInterface.GetPosition(bodyID);
+        JPH::Quat rot = bodyInterface.GetRotation(bodyID);
+        transform->position = glm::vec3(pos.GetX(), pos.GetY(), pos.GetZ());
+        glm::quat glmQuat(rot.GetW(), rot.GetX(), rot.GetY(), rot.GetZ());
+        glm::vec3 eulerAngles = glm::degrees(glm::eulerAngles(glmQuat));
+        transform->rotation = eulerAngles;
+    }
+}
+
+JPH::BodyID RigidbodyComponent::GetBodyID() const {
+    return bodyID;
+}
+
+void RigidbodyComponent::SetLinearVelocity(glm::vec3 velocity) {
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
+    auto& bodyInterface = physicsSystem->GetBodyInterface();
+    if (!bodyID.IsInvalid()) {
+        bodyInterface.SetLinearVelocity(bodyID, JPH::RVec3(velocity.x, velocity.y, velocity.z));
+    }
+}
+
+glm::vec3 RigidbodyComponent::GetLinearVelocity() const {
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
+    auto& bodyInterface = physicsSystem->GetBodyInterface();
+    if (!bodyID.IsInvalid()) {
+        JPH::RVec3 velocity = bodyInterface.GetLinearVelocity(bodyID);
+        return glm::vec3(velocity.GetX(), velocity.GetY(), velocity.GetZ());
+    }
+    return glm::vec3();
+}
+
+} // namespace NNE::Component::Physics

--- a/src/src/TransformComponent.cpp
+++ b/src/src/TransformComponent.cpp
@@ -1,13 +1,13 @@
-﻿#include "TransformComponent.h"
+#include "TransformComponent.h"
 
-NNE::TransformComponent::TransformComponent()
+NNE::Component::TransformComponent::TransformComponent()
 {
-	position = glm::vec3(0.0f);
-	rotation = glm::vec3(0.0f);
-	scale = glm::vec3(1.0f, 1.0f, 1.0f);	
+        position = glm::vec3(0.0f);
+        rotation = glm::vec3(0.0f);
+        scale = glm::vec3(1.0f, 1.0f, 1.0f);
 }
 
-void NNE::TransformComponent::Update(float deltaTime)
+void NNE::Component::TransformComponent::Update(float deltaTime)
 {
-	//rotation.y += 20.0f * deltaTime;	
+        //rotation.y += 20.0f * deltaTime;
 }

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -23,7 +23,7 @@ const std::vector<const char*> deviceExtensions = {
 const bool enableValidationLayers = true;
 
 
-NNE::VulkanManager::VulkanManager()
+NNE::Systems::VulkanManager::VulkanManager()
 {
     device = VK_NULL_HANDLE;
     instance = VK_NULL_HANDLE;
@@ -60,12 +60,12 @@ NNE::VulkanManager::VulkanManager()
     }
 }
 
-NNE::VulkanManager::~VulkanManager()
+NNE::Systems::VulkanManager::~VulkanManager()
 {
     CleanUp();
 }
 
-void NNE::VulkanManager::initVulkan()
+void NNE::Systems::VulkanManager::initVulkan()
 {
     CreateVulkanInstance();        // 1️⃣ Créer une instance Vulkan
     createSurface();               // 2️⃣ Créer la surface de rendu
@@ -85,7 +85,7 @@ void NNE::VulkanManager::initVulkan()
 
     createFramebuffers();           // 🖼 Associer toutes les ressources au framebuffer
 
-    LoadEntitiesModels(Application::GetInstance()->_entities); // 📦 Charger les modèles 3D
+    LoadEntitiesModels(NNE::Systems::Application::GetInstance()->_entities); // 📦 Charger les modèles 3D
     createVertexBuffer();           // 📦 Stocker les sommets des modèles
     createIndexBuffer();            // 📌 Stocker les indices des modèles
     createUniformBuffers();         // 🎭 Créer les buffers uniformes pour les shaders
@@ -101,7 +101,7 @@ void NNE::VulkanManager::initVulkan()
 }
 
 
-NNE::QueueFamilyIndices NNE::VulkanManager::findQueueFamilies(VkPhysicalDevice device)
+NNE::Systems::QueueFamilyIndices NNE::Systems::VulkanManager::findQueueFamilies(VkPhysicalDevice device)
 {
     QueueFamilyIndices indices;
 
@@ -139,7 +139,7 @@ NNE::QueueFamilyIndices NNE::VulkanManager::findQueueFamilies(VkPhysicalDevice d
     return indices;
 }
 
-bool NNE::VulkanManager::checkDeviceExtensionSupport(VkPhysicalDevice device)
+bool NNE::Systems::VulkanManager::checkDeviceExtensionSupport(VkPhysicalDevice device)
 {
     uint32_t extensionCount;
     vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, nullptr);
@@ -156,7 +156,7 @@ bool NNE::VulkanManager::checkDeviceExtensionSupport(VkPhysicalDevice device)
     return requiredExtensions.empty();
 }
 
-NNE::SwapChainSupportDetails NNE::VulkanManager::querySwapChainSupport(VkPhysicalDevice device)
+NNE::Systems::SwapChainSupportDetails NNE::Systems::VulkanManager::querySwapChainSupport(VkPhysicalDevice device)
 {
     SwapChainSupportDetails details;
 
@@ -180,7 +180,7 @@ NNE::SwapChainSupportDetails NNE::VulkanManager::querySwapChainSupport(VkPhysica
     return details;
 }
 
-VkSurfaceFormatKHR NNE::VulkanManager::chooseSwapSurfaceFormat(const std::vector<VkSurfaceFormatKHR>& availableFormats)
+VkSurfaceFormatKHR NNE::Systems::VulkanManager::chooseSwapSurfaceFormat(const std::vector<VkSurfaceFormatKHR>& availableFormats)
 {
     for (const auto& availableFormat : availableFormats) {
         if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB && availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
@@ -190,7 +190,7 @@ VkSurfaceFormatKHR NNE::VulkanManager::chooseSwapSurfaceFormat(const std::vector
     return availableFormats[0];
 }
 
-VkPresentModeKHR NNE::VulkanManager::chooseSwapPresentMode(const std::vector<VkPresentModeKHR>& availablePresentModes)
+VkPresentModeKHR NNE::Systems::VulkanManager::chooseSwapPresentMode(const std::vector<VkPresentModeKHR>& availablePresentModes)
 {
     for (const auto& availablePresentMode : availablePresentModes) {
         if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
@@ -201,7 +201,7 @@ VkPresentModeKHR NNE::VulkanManager::chooseSwapPresentMode(const std::vector<VkP
     return VK_PRESENT_MODE_FIFO_KHR;
 }
 
-VkExtent2D NNE::VulkanManager::chooseSwapExtent(const VkSurfaceCapabilitiesKHR& capabilities)
+VkExtent2D NNE::Systems::VulkanManager::chooseSwapExtent(const VkSurfaceCapabilitiesKHR& capabilities)
 {
     if (capabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()) {
         return capabilities.currentExtent;
@@ -222,7 +222,7 @@ VkExtent2D NNE::VulkanManager::chooseSwapExtent(const VkSurfaceCapabilitiesKHR& 
     }
 }
 
-uint32_t NNE::VulkanManager::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
+uint32_t NNE::Systems::VulkanManager::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
 {
     VkPhysicalDeviceMemoryProperties memProperties;
     vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProperties);
@@ -236,7 +236,7 @@ uint32_t NNE::VulkanManager::findMemoryType(uint32_t typeFilter, VkMemoryPropert
     throw std::runtime_error("failed to find suitable memory type!");    
 }
 
-void NNE::VulkanManager::CreateVulkanInstance()
+void NNE::Systems::VulkanManager::CreateVulkanInstance()
 {
     if (enableValidationLayers && !checkValidationLayerSupport()) {
         throw std::runtime_error("validation layers requested, but not available!");
@@ -281,7 +281,7 @@ void NNE::VulkanManager::CreateVulkanInstance()
     }
 }
 
-bool NNE::VulkanManager::checkValidationLayerSupport()
+bool NNE::Systems::VulkanManager::checkValidationLayerSupport()
 {
     uint32_t layerCount;
     vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
@@ -307,7 +307,7 @@ bool NNE::VulkanManager::checkValidationLayerSupport()
     return true;
 }
 
-void NNE::VulkanManager::pickPhysicalDevice()
+void NNE::Systems::VulkanManager::pickPhysicalDevice()
 {
     uint32_t deviceCount = 0;
         vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
@@ -332,7 +332,7 @@ void NNE::VulkanManager::pickPhysicalDevice()
         }
 } 
 
-void NNE::VulkanManager::createLogicalDevice()
+void NNE::Systems::VulkanManager::createLogicalDevice()
 {
     QueueFamilyIndices indices = findQueueFamilies(physicalDevice);
 
@@ -380,7 +380,7 @@ void NNE::VulkanManager::createLogicalDevice()
     vkGetDeviceQueue(device, indices.graphicsFamily.value(), 0, &graphicsQueue);    
 }
 
-GLFWwindow* NNE::VulkanManager::CreateGLFWWindow(int width, int height)
+GLFWwindow* NNE::Systems::VulkanManager::CreateGLFWWindow(int width, int height)
 {
     glfwInit();
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
@@ -391,20 +391,20 @@ GLFWwindow* NNE::VulkanManager::CreateGLFWWindow(int width, int height)
     return window;
 }
 
-void NNE::VulkanManager::framebufferResizeCallback(GLFWwindow* window, int width, int height)
+void NNE::Systems::VulkanManager::framebufferResizeCallback(GLFWwindow* window, int width, int height)
 {
     auto app = reinterpret_cast<VulkanManager*>(glfwGetWindowUserPointer(window));
     app->framebufferResized = true;
 }
 
-void NNE::VulkanManager::createSurface()
+void NNE::Systems::VulkanManager::createSurface()
 {
     if (glfwCreateWindowSurface(instance, window, nullptr, &surface) != VK_SUCCESS) {
         throw std::runtime_error("failed to create window surface!");
     }
 }
 
-void NNE::VulkanManager::createSwapChain()
+void NNE::Systems::VulkanManager::createSwapChain()
 {
     SwapChainSupportDetails swapChainSupport = querySwapChainSupport(physicalDevice);
 
@@ -459,7 +459,7 @@ void NNE::VulkanManager::createSwapChain()
     swapChainExtent = extent;
 }
 
-void NNE::VulkanManager::createImageViews()
+void NNE::Systems::VulkanManager::createImageViews()
 {
     swapChainImageViews.resize(swapChainImages.size());
 
@@ -468,7 +468,7 @@ void NNE::VulkanManager::createImageViews()
     }
 }
 
-VkImageView NNE::VulkanManager::createImageView(VkImage image, VkFormat format, VkImageAspectFlags aspectFlags, uint32_t mipLevels)
+VkImageView NNE::Systems::VulkanManager::createImageView(VkImage image, VkFormat format, VkImageAspectFlags aspectFlags, uint32_t mipLevels)
 {
     VkImageViewCreateInfo viewInfo{};
     viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -489,7 +489,7 @@ VkImageView NNE::VulkanManager::createImageView(VkImage image, VkFormat format, 
     return imageView;
 }
 
-void NNE::VulkanManager::createRenderPass()
+void NNE::Systems::VulkanManager::createRenderPass()
 {
     VkAttachmentDescription colorAttachment{};
     colorAttachment.format = swapChainImageFormat;
@@ -566,7 +566,7 @@ void NNE::VulkanManager::createRenderPass()
     }
 }
 
-void NNE::VulkanManager::createGraphicsPipeline()
+void NNE::Systems::VulkanManager::createGraphicsPipeline()
 {
     auto vertShaderCode = readFile("vert.spv");
     auto fragShaderCode = readFile("frag.spv");
@@ -705,7 +705,7 @@ void NNE::VulkanManager::createGraphicsPipeline()
     vkDestroyShaderModule(device, vertShaderModule, nullptr);
 }
 
-void NNE::VulkanManager::createBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, VkBuffer& buffer, VkDeviceMemory& bufferMemory)
+void NNE::Systems::VulkanManager::createBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, VkBuffer& buffer, VkDeviceMemory& bufferMemory)
 {
     VkBufferCreateInfo bufferInfo{};
     bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -734,7 +734,7 @@ void NNE::VulkanManager::createBuffer(VkDeviceSize size, VkBufferUsageFlags usag
     vkBindBufferMemory(device, buffer, bufferMemory, 0);
 }
 
-void NNE::VulkanManager::copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size)
+void NNE::Systems::VulkanManager::copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size)
 {
     VkCommandBuffer commandBuffer = beginSingleTimeCommands();
 
@@ -745,7 +745,7 @@ void NNE::VulkanManager::copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDe
     endSingleTimeCommands(commandBuffer);
 }
 
-void NNE::VulkanManager::createIndexBuffer()
+void NNE::Systems::VulkanManager::createIndexBuffer()
 {
     VkDeviceSize bufferSize = sizeof(indices[0]) * indices.size();
     /*std::cout << "Nombre d'indices : " << indices.size() << std::endl;
@@ -768,7 +768,7 @@ void NNE::VulkanManager::createIndexBuffer()
     vkFreeMemory(device, stagingBufferMemory, nullptr);
 }
 
-void NNE::VulkanManager::createVertexBuffer()
+void NNE::Systems::VulkanManager::createVertexBuffer()
 {
     VkDeviceSize bufferSize = sizeof(vertices[0]) * vertices.size();
 
@@ -791,7 +791,7 @@ void NNE::VulkanManager::createVertexBuffer()
     vkFreeMemory(device, stagingBufferMemory, nullptr);
 }
 
-void NNE::VulkanManager::createFramebuffers()
+void NNE::Systems::VulkanManager::createFramebuffers()
 {
     swapChainFramebuffers.resize(swapChainImageViews.size());
 
@@ -817,7 +817,7 @@ void NNE::VulkanManager::createFramebuffers()
     }
 }
 
-void NNE::VulkanManager::createCommandPool()
+void NNE::Systems::VulkanManager::createCommandPool()
 {
     QueueFamilyIndices queueFamilyIndices = findQueueFamilies(physicalDevice);
 
@@ -831,7 +831,7 @@ void NNE::VulkanManager::createCommandPool()
     }
 }
 
-void NNE::VulkanManager::createCommandBuffers()
+void NNE::Systems::VulkanManager::createCommandBuffers()
 {
     commandBuffers.resize(MAX_FRAMES_IN_FLIGHT);
 
@@ -847,7 +847,7 @@ void NNE::VulkanManager::createCommandBuffers()
     }
 }
 
-void NNE::VulkanManager::createUniformBuffers()
+void NNE::Systems::VulkanManager::createUniformBuffers()
 {
     // UBO global (vue/projection)
     VkDeviceSize globalBufferSize = sizeof(GlobalUniformBufferObject);
@@ -876,7 +876,7 @@ void NNE::VulkanManager::createUniformBuffers()
     }
 }
 
-void NNE::VulkanManager::recordCommandBuffer(VkCommandBuffer commandBuffer, uint32_t imageIndex)
+void NNE::Systems::VulkanManager::recordCommandBuffer(VkCommandBuffer commandBuffer, uint32_t imageIndex)
 {   
     VkCommandBufferBeginInfo beginInfo{};
     beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
@@ -925,10 +925,10 @@ void NNE::VulkanManager::recordCommandBuffer(VkCommandBuffer commandBuffer, uint
     vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
 
     // 🔥 Boucle pour dessiner les entités
-    const std::vector<AEntity*>& entities = Application::GetInstance()->_entities;
+    const std::vector<NNE::AEntity*>& entities = NNE::Systems::Application::GetInstance()->_entities;
     for (size_t i = 0; i < entities.size(); i++) {
-        TransformComponent* transform = entities[i]->GetComponent<TransformComponent>();
-        MeshComponent* mesh = dynamic_cast<MeshComponent*>(entities[i]->GetComponent<MeshComponent>());
+        NNE::Component::TransformComponent* transform = entities[i]->GetComponent<NNE::Component::TransformComponent>();
+        NNE::Component::Render::MeshComponent* mesh = dynamic_cast<NNE::Component::Render::MeshComponent*>(entities[i]->GetComponent<NNE::Component::Render::MeshComponent>());
 
         if (!mesh || mesh->getIndexCount() == 0) continue;
 
@@ -969,7 +969,7 @@ void NNE::VulkanManager::recordCommandBuffer(VkCommandBuffer commandBuffer, uint
     }
 }
 
-void NNE::VulkanManager::updateUniformBuffer(uint32_t currentImage)
+void NNE::Systems::VulkanManager::updateUniformBuffer(uint32_t currentImage)
 {
     static auto startTime = std::chrono::high_resolution_clock::now();
     auto currentTime = std::chrono::high_resolution_clock::now();
@@ -985,7 +985,7 @@ void NNE::VulkanManager::updateUniformBuffer(uint32_t currentImage)
         
 }
 
-void NNE::VulkanManager::loadModel(const std::string& modelPath)
+void NNE::Systems::VulkanManager::loadModel(const std::string& modelPath)
 {
     tinyobj::attrib_t attrib;
     std::vector<tinyobj::shape_t> shapes;
@@ -1031,7 +1031,7 @@ void NNE::VulkanManager::loadModel(const std::string& modelPath)
     std::cout << "Nombre d'indices : " << indices.size() << std::endl;*/
 }
 
-void NNE::VulkanManager::createDescriptorSetLayout()
+void NNE::Systems::VulkanManager::createDescriptorSetLayout()
 {
     // Binding 0 : UBO global pour la vue/projection
     VkDescriptorSetLayoutBinding globalUboLayoutBinding{};
@@ -1064,7 +1064,7 @@ void NNE::VulkanManager::createDescriptorSetLayout()
     }
 }
 
-void NNE::VulkanManager::createDescriptorPool()
+void NNE::Systems::VulkanManager::createDescriptorPool()
 {
     std::array<VkDescriptorPoolSize, 3> poolSizes{};
     poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -1085,7 +1085,7 @@ void NNE::VulkanManager::createDescriptorPool()
     }
 }
 
-void NNE::VulkanManager::createDescriptorSets()
+void NNE::Systems::VulkanManager::createDescriptorSets()
 {
     descriptorSets.resize(MAX_FRAMES_IN_FLIGHT);
 
@@ -1118,7 +1118,7 @@ void NNE::VulkanManager::createDescriptorSets()
     }
 }
 
-void NNE::VulkanManager::drawFrame()
+void NNE::Systems::VulkanManager::drawFrame()
 {
     try {
         vkWaitForFences(device, 1, &inFlightFences[currentFrame], VK_TRUE, UINT64_MAX);
@@ -1189,7 +1189,7 @@ void NNE::VulkanManager::drawFrame()
     }
 }
 
-void NNE::VulkanManager::createSyncObjects()
+void NNE::Systems::VulkanManager::createSyncObjects()
 {
     imageAvailableSemaphores.resize(MAX_FRAMES_IN_FLIGHT);
     renderFinishedSemaphores.resize(MAX_FRAMES_IN_FLIGHT);
@@ -1212,7 +1212,7 @@ void NNE::VulkanManager::createSyncObjects()
     }
 }
 
-void NNE::VulkanManager::recreateSwapChain()
+void NNE::Systems::VulkanManager::recreateSwapChain()
 {
     int width = 0, height = 0;
     glfwGetFramebufferSize(window, &width, &height);
@@ -1243,7 +1243,7 @@ void NNE::VulkanManager::recreateSwapChain()
 	updateCameraAspectRatio();
 }
 
-void NNE::VulkanManager::updateCameraAspectRatio()
+void NNE::Systems::VulkanManager::updateCameraAspectRatio()
 {
     if (activeCamera) {
         int width, height;
@@ -1255,7 +1255,7 @@ void NNE::VulkanManager::updateCameraAspectRatio()
     }
 }
 
-void NNE::VulkanManager::createTextureImage(const std::string& texturePath, VkImage& textureImage, VkDeviceMemory& textureImageMemory)
+void NNE::Systems::VulkanManager::createTextureImage(const std::string& texturePath, VkImage& textureImage, VkDeviceMemory& textureImageMemory)
 {
     int texWidth, texHeight, texChannels;
     stbi_uc* pixels = stbi_load(texturePath.c_str(), &texWidth, &texHeight, &texChannels, STBI_rgb_alpha);
@@ -1292,10 +1292,10 @@ void NNE::VulkanManager::createTextureImage(const std::string& texturePath, VkIm
     generateMipmaps(textureImage, VK_FORMAT_R8G8B8A8_SRGB, texWidth, texHeight, mipLevels);
 }
 
-void NNE::VulkanManager::LoadEntitiesModels(const std::vector<AEntity*>& entities)
+void NNE::Systems::VulkanManager::LoadEntitiesModels(const std::vector<NNE::AEntity*>& entities)
 {
-    for (AEntity* entity : entities) {
-        MeshComponent* mesh = dynamic_cast<MeshComponent*>(entity->GetComponent<MeshComponent>());
+    for (NNE::AEntity* entity : entities) {
+        NNE::Component::Render::MeshComponent* mesh = dynamic_cast<NNE::Component::Render::MeshComponent*>(entity->GetComponent<NNE::Component::Render::MeshComponent>());
         if (!mesh || mesh->getIndexCount() != 0) continue;
 
         uint32_t startOffset = static_cast<uint32_t>(indices.size());
@@ -1320,14 +1320,14 @@ void NNE::VulkanManager::LoadEntitiesModels(const std::vector<AEntity*>& entitie
     }
 }
 
-void NNE::VulkanManager::UpdateObjectUniformBuffer(uint32_t currentImage, const std::vector<AEntity*>& entities)
+void NNE::Systems::VulkanManager::UpdateObjectUniformBuffer(uint32_t currentImage, const std::vector<NNE::AEntity*>& entities)
 {
     // On suppose ici que pour chaque entité, on souhaite copier sa matrice modèle dans le buffer.
     // Le buffer est supposé être de taille MAX_OBJECTS * sizeof(glm::mat4).
     size_t offset = 0;
     // Parcourir les entités (attention : si le nombre d'entités dépasse MAX_OBJECTS, il faudra gérer ce cas)
     for (size_t i = 0; i < entities.size() && i < MAX_OBJECTS; i++) {
-        TransformComponent* transform = entities[i]->GetComponent<TransformComponent>();
+        NNE::Component::TransformComponent* transform = entities[i]->GetComponent<NNE::Component::TransformComponent>();
         if (transform) {
             glm::mat4 modelMatrix = transform->getModelMatrix();
             memcpy((char*)objectUniformBuffersMapped[currentImage] + offset, &modelMatrix, sizeof(glm::mat4));
@@ -1336,7 +1336,7 @@ void NNE::VulkanManager::UpdateObjectUniformBuffer(uint32_t currentImage, const 
     }
 }
 
-void NNE::VulkanManager::createImage(uint32_t width, uint32_t height, uint32_t mipLevels, VkSampleCountFlagBits numSamples, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& imageMemory)
+void NNE::Systems::VulkanManager::createImage(uint32_t width, uint32_t height, uint32_t mipLevels, VkSampleCountFlagBits numSamples, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& imageMemory)
 {
     VkImageCreateInfo imageInfo{};
     imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -1372,12 +1372,12 @@ void NNE::VulkanManager::createImage(uint32_t width, uint32_t height, uint32_t m
     vkBindImageMemory(device, image, imageMemory, 0);
 }
 
-void NNE::VulkanManager::createTextureImageView(VkImage textureImage, VkImageView& textureImageView)
+void NNE::Systems::VulkanManager::createTextureImageView(VkImage textureImage, VkImageView& textureImageView)
 {
     textureImageView = createImageView(textureImage, VK_FORMAT_R8G8B8A8_SRGB, VK_IMAGE_ASPECT_COLOR_BIT, mipLevels);
 }
 
-void NNE::VulkanManager::createTextureSampler(VkSampler& textureSampler)
+void NNE::Systems::VulkanManager::createTextureSampler(VkSampler& textureSampler)
 {
     VkPhysicalDeviceProperties properties{};
     vkGetPhysicalDeviceProperties(physicalDevice, &properties);
@@ -1405,7 +1405,7 @@ void NNE::VulkanManager::createTextureSampler(VkSampler& textureSampler)
     }
 }
 
-void NNE::VulkanManager::generateMipmaps(VkImage image, VkFormat imageFormat, int32_t texWidth, int32_t texHeight, uint32_t mipLevels)
+void NNE::Systems::VulkanManager::generateMipmaps(VkImage image, VkFormat imageFormat, int32_t texWidth, int32_t texHeight, uint32_t mipLevels)
 {
     // Check if image format supports linear blitting
     VkFormatProperties formatProperties;
@@ -1493,7 +1493,7 @@ void NNE::VulkanManager::generateMipmaps(VkImage image, VkFormat imageFormat, in
     endSingleTimeCommands(commandBuffer);
 }
 
-void NNE::VulkanManager::createDepthResources()
+void NNE::Systems::VulkanManager::createDepthResources()
 {
     VkFormat depthFormat = findDepthFormat();
     createImage(swapChainExtent.width, swapChainExtent.height, 1, msaaSamples, depthFormat, VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, depthImage, depthImageMemory);
@@ -1502,7 +1502,7 @@ void NNE::VulkanManager::createDepthResources()
 
 }
 
-VkFormat NNE::VulkanManager::findSupportedFormat(const std::vector<VkFormat>& candidates, VkImageTiling tiling, VkFormatFeatureFlags features)
+VkFormat NNE::Systems::VulkanManager::findSupportedFormat(const std::vector<VkFormat>& candidates, VkImageTiling tiling, VkFormatFeatureFlags features)
 {
     for (VkFormat format : candidates) {
         VkFormatProperties props;
@@ -1519,7 +1519,7 @@ VkFormat NNE::VulkanManager::findSupportedFormat(const std::vector<VkFormat>& ca
     throw std::runtime_error("failed to find supported format!");
 }
 
-VkFormat NNE::VulkanManager::findDepthFormat()
+VkFormat NNE::Systems::VulkanManager::findDepthFormat()
 {
     return findSupportedFormat(
         { VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT },
@@ -1528,12 +1528,12 @@ VkFormat NNE::VulkanManager::findDepthFormat()
     );
 }
 
-bool NNE::VulkanManager::hasStencilComponent(VkFormat format)
+bool NNE::Systems::VulkanManager::hasStencilComponent(VkFormat format)
 {
     return format == VK_FORMAT_D32_SFLOAT_S8_UINT || format == VK_FORMAT_D24_UNORM_S8_UINT;
 }
 
-VkSampleCountFlagBits NNE::VulkanManager::getMaxUsableSampleCount()
+VkSampleCountFlagBits NNE::Systems::VulkanManager::getMaxUsableSampleCount()
 {
     VkPhysicalDeviceProperties physicalDeviceProperties;
     vkGetPhysicalDeviceProperties(physicalDevice, &physicalDeviceProperties);
@@ -1549,7 +1549,7 @@ VkSampleCountFlagBits NNE::VulkanManager::getMaxUsableSampleCount()
     return VK_SAMPLE_COUNT_1_BIT;
 }
 
-VkCommandBuffer NNE::VulkanManager::beginSingleTimeCommands()
+VkCommandBuffer NNE::Systems::VulkanManager::beginSingleTimeCommands()
 {
     VkCommandBufferAllocateInfo allocInfo{};
     allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
@@ -1569,7 +1569,7 @@ VkCommandBuffer NNE::VulkanManager::beginSingleTimeCommands()
     return commandBuffer;
 }
 
-void NNE::VulkanManager::endSingleTimeCommands(VkCommandBuffer commandBuffer)
+void NNE::Systems::VulkanManager::endSingleTimeCommands(VkCommandBuffer commandBuffer)
 {
     vkEndCommandBuffer(commandBuffer);
 
@@ -1584,7 +1584,7 @@ void NNE::VulkanManager::endSingleTimeCommands(VkCommandBuffer commandBuffer)
     vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 }
 
-void NNE::VulkanManager::transitionImageLayout(VkImage image, VkFormat format, VkImageLayout oldLayout, VkImageLayout newLayout, uint32_t mipLevels)
+void NNE::Systems::VulkanManager::transitionImageLayout(VkImage image, VkFormat format, VkImageLayout oldLayout, VkImageLayout newLayout, uint32_t mipLevels)
 {
     VkCommandBuffer commandBuffer = beginSingleTimeCommands();
 
@@ -1653,7 +1653,7 @@ void NNE::VulkanManager::transitionImageLayout(VkImage image, VkFormat format, V
     endSingleTimeCommands(commandBuffer);
 }
 
-void NNE::VulkanManager::createColorResources()
+void NNE::Systems::VulkanManager::createColorResources()
 {
     VkFormat colorFormat = swapChainImageFormat;
 
@@ -1661,7 +1661,7 @@ void NNE::VulkanManager::createColorResources()
     colorImageView = createImageView(colorImage, colorFormat, VK_IMAGE_ASPECT_COLOR_BIT, 1);
 }
 
-void NNE::VulkanManager::copyBufferToImage(VkBuffer buffer, VkImage image, uint32_t width, uint32_t height)
+void NNE::Systems::VulkanManager::copyBufferToImage(VkBuffer buffer, VkImage image, uint32_t width, uint32_t height)
 {
     VkCommandBuffer commandBuffer = beginSingleTimeCommands();
 
@@ -1694,7 +1694,7 @@ void NNE::VulkanManager::copyBufferToImage(VkBuffer buffer, VkImage image, uint3
     endSingleTimeCommands(commandBuffer);   
 }
 
-VkShaderModule NNE::VulkanManager::createShaderModule(const std::vector<char>& code)
+VkShaderModule NNE::Systems::VulkanManager::createShaderModule(const std::vector<char>& code)
 {
     VkShaderModuleCreateInfo createInfo{};
     createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
@@ -1717,7 +1717,7 @@ std::string getEnginePath() {
     return path;
 }
 
-std::vector<char> NNE::VulkanManager::readFile(const std::string& filename)
+std::vector<char> NNE::Systems::VulkanManager::readFile(const std::string& filename)
 {
     std::string fullPath = getEnginePath() + filename;
     std::ifstream file(fullPath, std::ios::ate | std::ios::binary);
@@ -1737,15 +1737,15 @@ std::vector<char> NNE::VulkanManager::readFile(const std::string& filename)
     return buffer;
 }
 
-void NNE::VulkanManager::CleanUp()
+void NNE::Systems::VulkanManager::CleanUp()
 {    
     if (device == VK_NULL_HANDLE) return;
 
     vkDeviceWaitIdle(device);
 
-    // Ressources MeshComponent (très important !)
-    for (AEntity* entity : Application::GetInstance()->_entities) {
-        MeshComponent* mesh = dynamic_cast<MeshComponent*>(entity->GetComponent<MeshComponent>());
+    // Ressources NNE::Component::Render::MeshComponent (très important !)
+    for (NNE::AEntity* entity : NNE::Systems::Application::GetInstance()->_entities) {
+        NNE::Component::Render::MeshComponent* mesh = dynamic_cast<NNE::Component::Render::MeshComponent*>(entity->GetComponent<NNE::Component::Render::MeshComponent>());
         if (mesh) {
             if (mesh->textureSampler != VK_NULL_HANDLE) {
                 vkDestroySampler(device, mesh->textureSampler, nullptr);
@@ -1892,7 +1892,7 @@ void NNE::VulkanManager::CleanUp()
     }
 }
 
-void NNE::VulkanManager::cleanupSwapChain()
+void NNE::Systems::VulkanManager::cleanupSwapChain()
 {
     vkDeviceWaitIdle(device);
 
@@ -1904,8 +1904,8 @@ void NNE::VulkanManager::cleanupSwapChain()
     }
 
     //// Détruire aussi toutes les textures entités si vous les recréez après:
-    //for (AEntity* entity : Application::GetInstance()->_entities) {
-    //    if (MeshComponent* mesh = entity->GetComponent<MeshComponent>()) {
+    //for (NNE::AEntity* entity : NNE::Systems::Application::GetInstance()->_entities) {
+    //    if (NNE::Component::Render::MeshComponent* mesh = entity->GetComponent<NNE::Component::Render::MeshComponent>()) {
     //        if (mesh->textureSampler) {
     //            vkDestroySampler(device, mesh->textureSampler, nullptr);
     //            mesh->textureSampler = VK_NULL_HANDLE;
@@ -2008,7 +2008,7 @@ void NNE::VulkanManager::cleanupSwapChain()
     }
 }
 
-bool NNE::VulkanManager::isDeviceSuitable(VkPhysicalDevice device)
+bool NNE::Systems::VulkanManager::isDeviceSuitable(VkPhysicalDevice device)
 {
     QueueFamilyIndices indices = findQueueFamilies(device);   
     bool extensionsSupported = checkDeviceExtensionSupport(device);
@@ -2025,7 +2025,7 @@ bool NNE::VulkanManager::isDeviceSuitable(VkPhysicalDevice device)
     return indices.isComplete() && extensionsSupported && swapChainAdequate;
 }
 
-int NNE::VulkanManager::rateDeviceSuitability(VkPhysicalDevice device)
+int NNE::Systems::VulkanManager::rateDeviceSuitability(VkPhysicalDevice device)
 {
     int score = 0;
     //Get Device properties

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -11,7 +11,7 @@
 
 static void test_default_transform()
 {
-    NNE::TransformComponent t;
+    NNE::Component::TransformComponent t;
     assert(t.position == glm::vec3(0.0f));
     assert(t.rotation == glm::vec3(0.0f));
     assert(t.scale == glm::vec3(1.0f, 1.0f, 1.0f));
@@ -19,8 +19,8 @@ static void test_default_transform()
 
 static void test_parent_relationship()
 {
-    NNE::TransformComponent parent;
-    NNE::TransformComponent child;
+    NNE::Component::TransformComponent parent;
+    NNE::Component::TransformComponent child;
     child.SetParent(&parent);
     assert(child.parent == &parent);
     assert(parent.children.size() == 1);
@@ -29,7 +29,7 @@ static void test_parent_relationship()
 
 static void test_transform_directions()
 {
-    NNE::TransformComponent t;
+    NNE::Component::TransformComponent t;
     glm::vec3 forward = t.GetForward();
     glm::vec3 up = t.GetUp();
     assert(glm::all(glm::epsilonEqual(forward, glm::vec3(0, 0, -1), 0.0001f)));
@@ -38,9 +38,9 @@ static void test_transform_directions()
 
 static void test_world_position()
 {
-    NNE::TransformComponent parent;
+    NNE::Component::TransformComponent parent;
     parent.position = glm::vec3(1.0f, 2.0f, 3.0f);
-    NNE::TransformComponent child;
+    NNE::Component::TransformComponent child;
     child.position = glm::vec3(1.0f, 0.0f, 0.0f);
     child.SetParent(&parent);
     glm::vec3 worldPos = child.GetWorldPosition();
@@ -49,7 +49,7 @@ static void test_world_position()
 
 static void test_mesh_component_paths()
 {
-    NNE::MeshComponent m;
+    NNE::Component::Render::MeshComponent m;
     m.SetModelPath("model.obj");
     m.SetTexturePath("texture.png");
     assert(m.GetModelPath() == "model.obj");
@@ -58,7 +58,7 @@ static void test_mesh_component_paths()
 
 static void test_camera_perspective()
 {
-    NNE::CameraComponent c;
+    NNE::Component::Render::CameraComponent c;
     c.SetPerspective(60.0f, 4.0f/3.0f, 0.1f, 200.0f);
     assert(c.GetFOV() == 60.0f);
     assert(c.GetAspectRatio() == 4.0f/3.0f);
@@ -69,17 +69,17 @@ static void test_camera_perspective()
 static void test_entity_component_management()
 {
     NNE::AEntity e;
-    NNE::MeshComponent* mc = e.AddComponent<NNE::MeshComponent>();
+    NNE::Component::Render::MeshComponent* mc = e.AddComponent<NNE::Component::Render::MeshComponent>();
     assert(mc->GetEntity() == &e);
-    assert(e.GetComponent<NNE::MeshComponent>() == mc);
+    assert(e.GetComponent<NNE::Component::Render::MeshComponent>() == mc);
 }
 
 static void test_get_components_multiple()
 {
     NNE::AEntity e;
-    e.AddComponent<NNE::MeshComponent>();
-    e.AddComponent<NNE::MeshComponent>();
-    auto meshes = e.GetComponents<NNE::MeshComponent>();
+    e.AddComponent<NNE::Component::Render::MeshComponent>();
+    e.AddComponent<NNE::Component::Render::MeshComponent>();
+    auto meshes = e.GetComponents<NNE::Component::Render::MeshComponent>();
     assert(meshes.size() == 2);
     for (auto* m : meshes) {
         assert(m->GetEntity() == &e);
@@ -88,14 +88,14 @@ static void test_get_components_multiple()
 
 static void test_application_id_increment()
 {
-    int id1 = NNE::Application::GetInstance()->GenerateID();
-    int id2 = NNE::Application::GetInstance()->GenerateID();
+    int id1 = NNE::Systems::Application::GetInstance()->GenerateID();
+    int id2 = NNE::Systems::Application::GetInstance()->GenerateID();
     assert(id2 == id1 + 1);
 }
 
 static void test_model_matrix_translation()
 {
-    NNE::TransformComponent t;
+    NNE::Component::TransformComponent t;
     t.position = glm::vec3(1.0f, 2.0f, 3.0f);
     glm::mat4 mat = t.getModelMatrix();
     glm::vec3 trans(mat[3]);
@@ -108,7 +108,7 @@ static void test_scene_serialization()
 
     NNE::AEntity* e1 = new NNE::AEntity();
     e1->transform->position = glm::vec3(1.0f, 2.0f, 3.0f);
-    NNE::MeshComponent* m1 = e1->AddComponent<NNE::MeshComponent>();
+    NNE::Component::Render::MeshComponent* m1 = e1->AddComponent<NNE::Component::Render::MeshComponent>();
     m1->SetModelPath("model1.obj");
     m1->SetTexturePath("texture1.png");
     scene.entities.push_back(e1);
@@ -125,14 +125,14 @@ static void test_scene_serialization()
     assert(loadedOk);
     assert(loaded.entities.size() == 2);
 
-    auto* lt1 = loaded.entities[0]->GetComponent<NNE::TransformComponent>();
-    auto* lm1 = loaded.entities[0]->GetComponent<NNE::MeshComponent>();
+    auto* lt1 = loaded.entities[0]->GetComponent<NNE::Component::TransformComponent>();
+    auto* lm1 = loaded.entities[0]->GetComponent<NNE::Component::Render::MeshComponent>();
     assert(lt1 && lm1);
     assert(glm::all(glm::epsilonEqual(lt1->position, glm::vec3(1.0f, 2.0f, 3.0f), 0.0001f)));
     assert(lm1->GetModelPath() == "model1.obj");
     assert(lm1->GetTexturePath() == "texture1.png");
 
-    auto* lt2 = loaded.entities[1]->GetComponent<NNE::TransformComponent>();
+    auto* lt2 = loaded.entities[1]->GetComponent<NNE::Component::TransformComponent>();
     assert(lt2);
     assert(glm::all(glm::epsilonEqual(lt2->position, glm::vec3(4.0f, 5.0f, 6.0f), 0.0001f)));
 
@@ -141,7 +141,7 @@ static void test_scene_serialization()
 
 int main()
 {
-    NNE::Application app;
+    NNE::Systems::Application app;
     test_application_id_increment();
     test_default_transform();
     test_parent_relationship();


### PR DESCRIPTION
## Summary
- group systems like Application, VulkanManager, PhysicsManager, and InputManager into `NNE::Systems`
- nest rendering and physics components under `NNE::Component::Render` and `NNE::Component::Physics`
- update examples and tests to use new namespaced classes

