### PR TITLE
Add RenderSystem for Vulkan draw call management

### DIFF
--- a/src/include/Application.h
+++ b/src/include/Application.h
@@ -9,6 +9,7 @@
 #include "CameraComponent.h"
 #include "VulkanManager.h"
 #include "PhysicsManager.h"
+#include "RenderSystem.h"
 #include "PlaneCollider.h"
 #include "BoxColliderComponent.h"
 #include "RigidbodyComponent.h"
@@ -43,6 +44,7 @@ namespace NNE::Systems {
                 ~Application();
                 NNE::Systems::VulkanManager* VKManager;
                 NNE::Systems::PhysicsManager* physicsManager;
+                NNE::Systems::RenderSystem* renderSystem;
                 std::vector<NNE::AEntity*> _entities;
                 std::vector<NNE::Systems::ISystem*>& _systems;
 

--- a/src/include/RenderSystem.h
+++ b/src/include/RenderSystem.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <vector>
+#include <utility>
+#include "ISystem.h"
+#include "MeshComponent.h"
+#include "TransformComponent.h"
+
+namespace NNE::Systems {
+class VulkanManager;
+
+class RenderSystem : public ISystem {
+private:
+    VulkanManager* _vkManager;
+    std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>> _renderObjects;
+
+public:
+    explicit RenderSystem(VulkanManager* manager);
+    ~RenderSystem() = default;
+
+    void Awake() override {}
+    void Start() override;
+    void Update(float deltaTime) override;
+    void LateUpdate(float deltaTime) override {}
+    void RegisterComponent(NNE::Component::AComponent* component) override;
+
+    const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& GetRenderObjects() const;
+};
+}
+

--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -14,7 +14,10 @@
 #include <fstream>
 #include <array>
 #include <unordered_map>
+#include <utility>
 #include "CameraComponent.h"
+#include "MeshComponent.h"
+#include "TransformComponent.h"
 
 #define NOMINMAX //Necessary for ::Max()
 #define VK_USE_PLATFORM_WIN32_KHR
@@ -38,7 +41,6 @@
 
 
 
-namespace NNE { class AEntity; }
 
 namespace NNE::Systems {
         struct QueueFamilyIndices {
@@ -146,9 +148,11 @@ namespace NNE::Systems {
 		std::vector<VkDeviceMemory> uniformBuffersMemory;
 		std::vector<void*> uniformBuffersMapped;
 
-		std::vector<VkBuffer> objectUniformBuffers;
-		std::vector<VkDeviceMemory> objectUniformBuffersMemory;
-		std::vector<void*> objectUniformBuffersMapped;
+                std::vector<VkBuffer> objectUniformBuffers;
+                std::vector<VkDeviceMemory> objectUniformBuffersMemory;
+                std::vector<void*> objectUniformBuffersMapped;
+
+                std::vector<NNE::Component::Render::MeshComponent*> loadedMeshes;
 
 		VkBuffer vertexBuffer;
 		VkDeviceMemory vertexBufferMemory;
@@ -202,14 +206,14 @@ namespace NNE::Systems {
 		void createVertexBuffer();
 		void createFramebuffers();
 		void createCommandPool();
-		void createCommandBuffers();
-		void createUniformBuffers();
-		void recordCommandBuffer(VkCommandBuffer commandBuffer, uint32_t imageIndex);
+                void createCommandBuffers();
+                void createUniformBuffers();
+                void recordCommandBuffer(VkCommandBuffer commandBuffer, uint32_t imageIndex, const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& objects);
 		void updateUniformBuffer(uint32_t currentImage);
 		void createDescriptorSetLayout();
 		void createDescriptorPool();
-		void createDescriptorSets();
-		void drawFrame();
+                void createDescriptorSets();
+                void drawFrame(const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& objects);
 		void createSyncObjects();
 		void recreateSwapChain();
 		void updateCameraAspectRatio();
@@ -223,10 +227,8 @@ namespace NNE::Systems {
 		void createColorResources();
 
 		void loadModel(const std::string& modelPath);
-		void createTextureImage(const std::string& texturePath, VkImage& textureImage, VkDeviceMemory& textureImageMemory);
-		void LoadEntitiesModels(const std::vector<AEntity*>& entities);
-
-		void UpdateObjectUniformBuffer(uint32_t currentImage, const std::vector<AEntity*>& entities);
+                void createTextureImage(const std::string& texturePath, VkImage& textureImage, VkDeviceMemory& textureImageMemory);
+                void LoadMeshes(const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& objects);
 
 		VkSampleCountFlagBits getMaxUsableSampleCount();
 

--- a/src/src/Application.cpp
+++ b/src/src/Application.cpp
@@ -11,7 +11,9 @@ NNE::Systems::Application::Application()
     Instance = this;
     VKManager = new VulkanManager();
     physicsManager = new PhysicsManager();
+    renderSystem = new RenderSystem(VKManager);
     NNE::Systems::SystemManager::GetInstance()->AddSystem(physicsManager);
+    NNE::Systems::SystemManager::GetInstance()->AddSystem(renderSystem);
     delta = 0;
 }
 
@@ -21,6 +23,12 @@ NNE::Systems::Application::~Application()
         VKManager->CleanUp();
         delete VKManager;
         VKManager = nullptr;
+    }
+
+    if (renderSystem)
+    {
+        delete renderSystem;
+        renderSystem = nullptr;
     }
 
     for (NNE::AEntity* entity : _entities) {
@@ -74,8 +82,6 @@ void NNE::Systems::Application::Update()
         {
             entity->LateUpdate(delta);
         }
-
-        VKManager->drawFrame();
     }
     vkDeviceWaitIdle(VKManager->device);
 }

--- a/src/src/RenderSystem.cpp
+++ b/src/src/RenderSystem.cpp
@@ -1,0 +1,49 @@
+#include "RenderSystem.h"
+#include "VulkanManager.h"
+#include "AComponent.h"
+
+using namespace NNE::Systems;
+
+RenderSystem::RenderSystem(VulkanManager* manager) : _vkManager(manager) {}
+
+void RenderSystem::Start()
+{
+    if (_vkManager)
+    {
+        _vkManager->LoadMeshes(_renderObjects);
+        _vkManager->createVertexBuffer();
+        _vkManager->createIndexBuffer();
+        _vkManager->createUniformBuffers();
+        _vkManager->createDescriptorPool();
+        _vkManager->createDescriptorSets();
+        _vkManager->createCommandBuffers();
+        _vkManager->createSyncObjects();
+    }
+}
+
+void RenderSystem::Update(float deltaTime)
+{
+    (void)deltaTime;
+    if (_vkManager)
+    {
+        _vkManager->drawFrame(_renderObjects);
+    }
+}
+
+void RenderSystem::RegisterComponent(NNE::Component::AComponent* component)
+{
+    if (auto* mesh = dynamic_cast<NNE::Component::Render::MeshComponent*>(component))
+    {
+        NNE::Component::TransformComponent* transform = mesh->GetEntity()->GetComponent<NNE::Component::TransformComponent>();
+        if (transform)
+        {
+            _renderObjects.emplace_back(mesh, transform);
+        }
+    }
+}
+
+const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& RenderSystem::GetRenderObjects() const
+{
+    return _renderObjects;
+}
+


### PR DESCRIPTION
## Summary
- Implement RenderSystem derived from ISystem to track mesh and transform components and drive Vulkan rendering
- Integrate RenderSystem into Application lifecycle and VulkanManager
- Refactor VulkanManager to accept draw-call data instead of querying entities directly

