### PR TITLE
Rename PhysicsManager to PhysicsSystem and centralize physics updates

### DIFF
--- a/src/include/Application.h
+++ b/src/include/Application.h
@@ -8,7 +8,7 @@
 #include "TransformComponent.h"
 #include "CameraComponent.h"
 #include "VulkanManager.h"
-#include "PhysicsManager.h"
+#include "PhysicsSystem.h"
 #include "RenderSystem.h"
 #include "PlaneCollider.h"
 #include "BoxColliderComponent.h"
@@ -43,7 +43,7 @@ namespace NNE::Systems {
                 Application();
                 ~Application();
                 NNE::Systems::VulkanManager* VKManager;
-                NNE::Systems::PhysicsManager* physicsManager;
+                NNE::Systems::PhysicsSystem* physicsSystem;
                 NNE::Systems::RenderSystem* renderSystem;
                 std::vector<NNE::AEntity*> _entities;
                 std::vector<NNE::Systems::ISystem*>& _systems;

--- a/src/include/PhysicsSystem.h
+++ b/src/include/PhysicsSystem.h
@@ -5,18 +5,24 @@
 #include <Jolt/Physics/PhysicsSystem.h>
 #include <Jolt/RegisterTypes.h>
 #include "ISystem.h"
+#include <vector>
+
+namespace NNE { namespace Component { class AComponent; } }
+namespace NNE { namespace Component { namespace Physics { class RigidbodyComponent; class ColliderComponent; } } }
 
 namespace NNE::Systems {
 
-    class PhysicsManager : public ISystem {
+    class PhysicsSystem : public ISystem {
     private:
         JPH::PhysicsSystem physicsSystem;
         JPH::TempAllocatorImpl* tempAllocator;
         JPH::JobSystemThreadPool* jobSystem;
+        std::vector<NNE::Component::Physics::RigidbodyComponent*> rigidbodies;
+        std::vector<NNE::Component::Physics::ColliderComponent*> colliders;
 
     public:
-        PhysicsManager();
-        ~PhysicsManager();
+        PhysicsSystem();
+        ~PhysicsSystem();
 
         void Initialize();
         void Update(float deltaTime) override;

--- a/src/src/Application.cpp
+++ b/src/src/Application.cpp
@@ -10,9 +10,9 @@ NNE::Systems::Application::Application()
 {
     Instance = this;
     VKManager = new VulkanManager();
-    physicsManager = new PhysicsManager();
+    physicsSystem = new PhysicsSystem();
     renderSystem = new RenderSystem(VKManager);
-    NNE::Systems::SystemManager::GetInstance()->AddSystem(physicsManager);
+    NNE::Systems::SystemManager::GetInstance()->AddSystem(physicsSystem);
     NNE::Systems::SystemManager::GetInstance()->AddSystem(renderSystem);
     delta = 0;
 }
@@ -35,6 +35,12 @@ NNE::Systems::Application::~Application()
         delete entity;
     }
     _entities.clear();
+
+    if (physicsSystem)
+    {
+        delete physicsSystem;
+        physicsSystem = nullptr;
+    }
 }
 
 void NNE::Systems::Application::Init()

--- a/src/src/BoxColliderComponent.cpp
+++ b/src/src/BoxColliderComponent.cpp
@@ -17,7 +17,7 @@ void NNE::Component::Physics::BoxColliderComponent::CreateShape()
         shape = new JPH::BoxShape(JPH::Vec3(size.x, size.y, size.z));
 
         JPH::BodyCreationSettings bodySettings(shape, JPH::RVec3::sZero(), JPH::Quat::sIdentity(), JPH::EMotionType::Dynamic, 0);
-        auto& bodyInterface = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem()->GetBodyInterface();
+        auto& bodyInterface = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem()->GetBodyInterface();
         bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
 
         NNE::Systems::Application::GetInstance()->RegisterCollider(bodyID, this);

--- a/src/src/RigidbodyComponent.cpp
+++ b/src/src/RigidbodyComponent.cpp
@@ -10,14 +10,14 @@ RigidbodyComponent::RigidbodyComponent(float mass, bool kinematic)
 }
 
 RigidbodyComponent::~RigidbodyComponent() {
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
     if (!bodyID.IsInvalid()) {
         physicsSystem->GetBodyInterface().RemoveBody(bodyID);
     }
 }
 
 void RigidbodyComponent::Awake() {
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
     auto* transform = GetEntity()->GetComponent<NNE::Component::TransformComponent>();
     auto* collider = GetEntity()->GetComponent<NNE::Component::Physics::ColliderComponent>();
 
@@ -41,17 +41,7 @@ void RigidbodyComponent::Awake() {
 }
 
 void RigidbodyComponent::Update(float deltaTime) {
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
-    auto& bodyInterface = physicsSystem->GetBodyInterface();
-    if (!bodyID.IsInvalid()) {
-        auto* transform = GetEntity()->GetComponent<NNE::Component::TransformComponent>();
-        JPH::RVec3 pos = bodyInterface.GetPosition(bodyID);
-        JPH::Quat rot = bodyInterface.GetRotation(bodyID);
-        transform->position = glm::vec3(pos.GetX(), pos.GetY(), pos.GetZ());
-        glm::quat glmQuat(rot.GetW(), rot.GetX(), rot.GetY(), rot.GetZ());
-        glm::vec3 eulerAngles = glm::degrees(glm::eulerAngles(glmQuat));
-        transform->rotation = eulerAngles;
-    }
+    (void)deltaTime;
 }
 
 JPH::BodyID RigidbodyComponent::GetBodyID() const {
@@ -59,7 +49,7 @@ JPH::BodyID RigidbodyComponent::GetBodyID() const {
 }
 
 void RigidbodyComponent::SetLinearVelocity(glm::vec3 velocity) {
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
     auto& bodyInterface = physicsSystem->GetBodyInterface();
     if (!bodyID.IsInvalid()) {
         bodyInterface.SetLinearVelocity(bodyID, JPH::RVec3(velocity.x, velocity.y, velocity.z));
@@ -67,7 +57,7 @@ void RigidbodyComponent::SetLinearVelocity(glm::vec3 velocity) {
 }
 
 glm::vec3 RigidbodyComponent::GetLinearVelocity() const {
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsManager->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
     auto& bodyInterface = physicsSystem->GetBodyInterface();
     if (!bodyID.IsInvalid()) {
         JPH::RVec3 velocity = bodyInterface.GetLinearVelocity(bodyID);


### PR DESCRIPTION
## Summary
- Rename PhysicsManager to PhysicsSystem and expose lists of registered rigidbodies and colliders
- Update PhysicsSystem to step Jolt physics and sync component transforms
- Wire the new PhysicsSystem into Application startup and cleanup

