### PR TITLE
Add ScriptSystem for MonoComponent updates

### DIFF
--- a/src/include/Application.h
+++ b/src/include/Application.h
@@ -11,6 +11,7 @@
 #include "PhysicsSystem.h"
 #include "RenderSystem.h"
 #include "InputSystem.h"
+#include "ScriptSystem.h"
 #include "PlaneCollider.h"
 #include "BoxColliderComponent.h"
 #include "RigidbodyComponent.h"
@@ -47,6 +48,7 @@ namespace NNE::Systems {
                 NNE::Systems::PhysicsSystem* physicsSystem;
                 NNE::Systems::RenderSystem* renderSystem;
                 NNE::Systems::InputSystem* inputSystem;
+                NNE::Systems::ScriptSystem* scriptSystem;
                 std::vector<NNE::AEntity*> _entities;
                 std::vector<NNE::Systems::ISystem*>& _systems;
 

--- a/src/include/ScriptSystem.h
+++ b/src/include/ScriptSystem.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "ISystem.h"
+#include "MonoComponent.h"
+#include <vector>
+
+namespace NNE::Systems {
+
+class ScriptSystem : public ISystem {
+private:
+    std::vector<NNE::Component::MonoComponent*> _components;
+
+public:
+    void Awake() override {}
+    void Start() override {}
+    void Update(float deltaTime) override;
+    void LateUpdate(float deltaTime) override;
+    void RegisterComponent(NNE::Component::AComponent* component) override;
+};
+
+}

--- a/src/src/AEntity.cpp
+++ b/src/src/AEntity.cpp
@@ -1,5 +1,6 @@
 #include "AEntity.h"
 #include "Application.h"
+#include "MonoComponent.h"
 
 
 NNE::AEntity::AEntity()
@@ -44,7 +45,8 @@ void NNE::AEntity::Update(float delta)
 {
         if (!components.empty()) {
                 for (NNE::Component::AComponent* component : components) {
-                        component->Update(delta);
+                        if (!dynamic_cast<NNE::Component::MonoComponent*>(component))
+                                component->Update(delta);
                 }
         }
 }
@@ -53,7 +55,8 @@ void NNE::AEntity::LateUpdate(float delta)
 {
         if (!components.empty()) {
                 for (NNE::Component::AComponent* component : components) {
-                        component->LateUpdate(delta);
+                        if (!dynamic_cast<NNE::Component::MonoComponent*>(component))
+                                component->LateUpdate(delta);
                 }
         }
 }

--- a/src/src/Application.cpp
+++ b/src/src/Application.cpp
@@ -13,9 +13,11 @@ NNE::Systems::Application::Application()
     physicsSystem = new PhysicsSystem();
     renderSystem = new RenderSystem(VKManager);
     inputSystem = new InputSystem();
+    scriptSystem = new ScriptSystem();
     NNE::Systems::SystemManager::GetInstance()->AddSystem(physicsSystem);
     NNE::Systems::SystemManager::GetInstance()->AddSystem(renderSystem);
     NNE::Systems::SystemManager::GetInstance()->AddSystem(inputSystem);
+    NNE::Systems::SystemManager::GetInstance()->AddSystem(scriptSystem);
     delta = 0;
 }
 
@@ -37,6 +39,12 @@ NNE::Systems::Application::~Application()
     {
         delete inputSystem;
         inputSystem = nullptr;
+    }
+
+    if (scriptSystem)
+    {
+        delete scriptSystem;
+        scriptSystem = nullptr;
     }
 
     for (NNE::AEntity* entity : _entities) {

--- a/src/src/ScriptSystem.cpp
+++ b/src/src/ScriptSystem.cpp
@@ -1,0 +1,27 @@
+#include "ScriptSystem.h"
+
+using namespace NNE::Systems;
+
+void ScriptSystem::Update(float deltaTime)
+{
+    for (auto* comp : _components)
+    {
+        comp->Update(deltaTime);
+    }
+}
+
+void ScriptSystem::LateUpdate(float deltaTime)
+{
+    for (auto* comp : _components)
+    {
+        comp->LateUpdate(deltaTime);
+    }
+}
+
+void ScriptSystem::RegisterComponent(NNE::Component::AComponent* component)
+{
+    if (auto* mono = dynamic_cast<NNE::Component::MonoComponent*>(component))
+    {
+        _components.push_back(mono);
+    }
+}


### PR DESCRIPTION
## Summary
- Add ScriptSystem derived from ISystem to handle MonoComponent updates
- Register ScriptSystem in Application and SystemManager
- Avoid updating MonoComponents directly in AEntity, letting ScriptSystem manage them

