### PR TITLE
Use unified NNE::Debug namespace for DebugOverlay

### DIFF
--- a/src/include/DebugOverlay.h
+++ b/src/include/DebugOverlay.h
@@ -1,13 +1,13 @@
 #pragma once
 #include "imgui.h"
 
-namespace NNE::Editor {
-	class DebugOverlay {
-		public:
-			void Init();
-			void Render();
-			void Shutdown();
-	};
-} // namespace NNE
+namespace NNE::Debug {
+class DebugOverlay {
+public:
+    void Init();
+    void Render();
+    void Shutdown();
+};
+} // namespace NNE::Debug
 
 

--- a/src/src/Application.cpp
+++ b/src/src/Application.cpp
@@ -1,6 +1,7 @@
 #include "Application.h"
 #include "SystemManager.h"
 #include "DebugOverlay.h"
+using NNE::Debug::DebugOverlay;
 
 std::clock_t lastFrameTime;
 NNE::Systems::Application* NNE::Systems::Application::Instance = nullptr;
@@ -125,7 +126,7 @@ void NNE::Systems::Application::Update()
             entity->LateUpdate(delta);
         }
 
-        NNE::Debug::DebugOverlay::Render();
+        DebugOverlay::Render();
     }
     vkDeviceWaitIdle(VKManager->device);
 }

--- a/src/src/DebugOverlay.cpp
+++ b/src/src/DebugOverlay.cpp
@@ -1,7 +1,7 @@
 #include "DebugOverlay.h"
 
 
-namespace NNE {
+namespace NNE::Debug {
 
 void DebugOverlay::Init() {
     ImGui::CreateContext();
@@ -19,6 +19,6 @@ void DebugOverlay::Shutdown() {
     ImGui::DestroyContext();
 }
 
-} // namespace NNE
+} // namespace NNE::Debug
 
 

--- a/src/src/RenderSystem.cpp
+++ b/src/src/RenderSystem.cpp
@@ -34,7 +34,7 @@ void RenderSystem::Start()
         _vkManager->createDescriptorSets();
         _vkManager->createCommandBuffers();
         _vkManager->createSyncObjects();
-        NNE::Debug::DebugOverlay::Init(_vkManager);
+        NNE::Debug::DebugOverlay::Init();
     }
 }
 


### PR DESCRIPTION
## Summary
- place DebugOverlay in `NNE::Debug` namespace
- update call sites in Application and RenderSystem
- adjust DebugOverlay implementation for namespace

