### PR TITLE
Add profiling overlay using ImGui

### DIFF
--- a/src/include/Application.h
+++ b/src/include/Application.h
@@ -52,6 +52,7 @@ namespace NNE::Systems {
                 * </summary>
                 */
             static Application* GetInstance();
+            float GetDelta() const;
             /**
                 * <summary>
                 * Construit l'application et initialise les systèmes principaux.

--- a/src/include/imgui.h
+++ b/src/include/imgui.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 // Minimal ImGui stub for compilation in NNEngine tests.
 // Provides enough interface used by DebugOverlay and VulkanManager.
 
@@ -8,8 +7,11 @@ struct ImGuiIO {
     int ConfigFlags = 0;
 };
 
-// Config flag for enabling viewports
+struct ImGuiViewport {};
+
+// Config flags
 constexpr int ImGuiConfigFlags_ViewportsEnable = 1 << 10;
+constexpr int ImGuiConfigFlags_DockingEnable   = 1 << 7;
 
 namespace ImGui {
 inline void CreateContext() {}
@@ -24,6 +26,15 @@ inline ImGuiIO& GetIO() {
     static ImGuiIO io{};
     return io;
 }
-} // namespace ImGui
 
+inline ImGuiViewport* GetMainViewport() {
+    static ImGuiViewport viewport;
+    return &viewport;
+}
+inline void DockSpaceOverViewport(ImGuiViewport*, int = 0) {}
+
+inline bool Begin(const char*, bool* = nullptr, int = 0) { return true; }
+inline void End() {}
+inline void Text(const char*, ...) {}
+} // namespace ImGui
 

--- a/src/src/Application.cpp
+++ b/src/src/Application.cpp
@@ -35,6 +35,7 @@ NNE::Systems::Application::Application()
  */
 NNE::Systems::Application::~Application()
 {
+    DebugOverlay::Shutdown();
     if (VKManager) {
         VKManager->CleanUp();
         delete VKManager;
@@ -197,4 +198,9 @@ float NNE::Systems::Application::GetDeltaTime()
 NNE::Systems::Application* NNE::Systems::Application::GetInstance()
 {
     return Instance;
+}
+
+float NNE::Systems::Application::GetDelta() const
+{
+    return delta;
 }

--- a/src/src/DebugOverlay.cpp
+++ b/src/src/DebugOverlay.cpp
@@ -1,23 +1,33 @@
 #include "DebugOverlay.h"
-
+#include "Application.h"
 
 namespace NNE::Debug {
 
-void  DebugOverlay::Init() {
+void DebugOverlay::Init() {
     ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
-	
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 }
 
-void  DebugOverlay::Render() {
+void DebugOverlay::Render() {
+    ImGui::NewFrame();
+    ImGui::DockSpaceOverViewport(ImGui::GetMainViewport());
+
+    if (ImGui::Begin("Profiler")) {
+        auto* app = NNE::Systems::Application::GetInstance();
+        float dt = app ? app->GetDelta() : 0.0f;
+        float fps = dt > 0.0f ? 1.0f / dt : 0.0f;
+        ImGui::Text("Frame time: %.3f ms (%.1f FPS)", dt * 1000.0f, fps);
+    }
+    ImGui::End();
+
     ImGui::Render();
     ImGui::UpdatePlatformWindows();
     ImGui::RenderPlatformWindowsDefault();
-    ImGui::DockSpaceOverViewport(ImGui::GetMainViewport());
 }
 
-void  DebugOverlay::Shutdown() {
+void DebugOverlay::Shutdown() {
     ImGui::DestroyPlatformWindows();
     ImGui::DestroyContext();
 }


### PR DESCRIPTION
## Summary
- add minimal ImGui stub support for docking and profiling widgets
- expose frame delta time from Application and show it in new profiler window
- ensure debug overlay cleans up context when application exits

