### PR TITLE
Integrate ImGui overlay with Vulkan renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,29 @@ if(NOT nlohmann_json_FOUND)
     FetchContent_MakeAvailable(nlohmann_json)
 endif()
 
-target_link_libraries(NNEngine PUBLIC glfw glm::glm Vulkan::Vulkan tinyobjloader::tinyobjloader Jolt::Jolt nlohmann_json::nlohmann_json)
+include(FetchContent)
+FetchContent_Declare(
+    imgui
+    GIT_REPOSITORY https://github.com/ocornut/imgui.git
+    GIT_TAG v1.90.4
+)
+FetchContent_GetProperties(imgui)
+if(NOT imgui_POPULATED)
+    FetchContent_Populate(imgui)
+endif()
+
+add_library(imgui STATIC
+    ${imgui_SOURCE_DIR}/imgui.cpp
+    ${imgui_SOURCE_DIR}/imgui_draw.cpp
+    ${imgui_SOURCE_DIR}/imgui_tables.cpp
+    ${imgui_SOURCE_DIR}/imgui_widgets.cpp
+    ${imgui_SOURCE_DIR}/backends/imgui_impl_glfw.cpp
+    ${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp
+)
+target_include_directories(imgui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)
+target_link_libraries(imgui PUBLIC glfw Vulkan::Vulkan)
+
+target_link_libraries(NNEngine PUBLIC glfw glm::glm Vulkan::Vulkan tinyobjloader::tinyobjloader Jolt::Jolt nlohmann_json::nlohmann_json imgui)
 
 # ---------------- Example ----------------
 file(GLOB EXAMPLE_SOURCES examples/src/*.cpp)

--- a/src/include/Application.h
+++ b/src/include/Application.h
@@ -10,6 +10,7 @@
 #include "VulkanManager.h"
 #include "PhysicsSystem.h"
 #include "RenderSystem.h"
+#include "UISystem.h"
 #include "InputSystem.h"
 #include "ScriptSystem.h"
 #include "PlaneCollider.h"
@@ -66,6 +67,7 @@ namespace NNE::Systems {
                 ~Application();
                 NNE::Systems::VulkanManager* VKManager;
                 NNE::Systems::PhysicsSystem* physicsSystem;
+                NNE::Systems::UISystem* uiSystem;
                 NNE::Systems::RenderSystem* renderSystem;
                 NNE::Systems::InputSystem* inputSystem;
                 NNE::Systems::ScriptSystem* scriptSystem;

--- a/src/include/PerformanceMetrics.h
+++ b/src/include/PerformanceMetrics.h
@@ -1,0 +1,5 @@
+#pragma once
+
+extern float g_FrameTimeMs;
+extern float g_FPS;
+

--- a/src/include/UISystem.h
+++ b/src/include/UISystem.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "ISystem.h"
+
+namespace NNE { namespace Component { class AComponent; } }
+
+namespace NNE::Systems {
+class VulkanManager;
+
+class UISystem : public ISystem {
+    VulkanManager* _vkManager;
+public:
+    explicit UISystem(VulkanManager* manager);
+    void Awake() override {}
+    void Start() override;
+    void Update(float deltaTime) override;
+    void LateUpdate(float deltaTime) override;
+    void RegisterComponent(NNE::Component::AComponent* component) override {}
+};
+}
+

--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -170,8 +170,9 @@ namespace NNE::Systems {
 		VkDeviceMemory colorImageMemory;
 		VkImageView colorImageView;
 
-		VkDescriptorPool descriptorPool;
-		std::vector<VkDescriptorSet> descriptorSets;
+                VkDescriptorPool descriptorPool;
+                VkDescriptorPool imguiPool;
+                std::vector<VkDescriptorSet> descriptorSets;
 
 		VkImage depthImage;
 		VkDeviceMemory depthImageMemory;
@@ -473,6 +474,10 @@ namespace NNE::Systems {
                  * </summary>
                  */
                 void endSingleTimeCommands(VkCommandBuffer commandBuffer);
+                void initImGui();
+                void cleanupImGui();
+                void beginImGuiFrame();
+                void renderImGui(VkCommandBuffer commandBuffer);
                 /**
                  * <summary>
                  * Change l'agencement d'une image.

--- a/src/src/PerformanceMetrics.cpp
+++ b/src/src/PerformanceMetrics.cpp
@@ -1,0 +1,5 @@
+#include "PerformanceMetrics.h"
+
+float g_FrameTimeMs = 0.0f;
+float g_FPS = 0.0f;
+

--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -1,0 +1,40 @@
+#include "UISystem.h"
+#include "VulkanManager.h"
+#include "PerformanceMetrics.h"
+#include <imgui.h>
+
+using namespace NNE::Systems;
+
+UISystem::UISystem(VulkanManager* manager) : _vkManager(manager) {}
+
+void UISystem::Start() {
+    if (_vkManager) {
+        _vkManager->initImGui();
+    }
+}
+
+void UISystem::Update(float deltaTime) {
+    (void)deltaTime;
+    if (!_vkManager) return;
+
+    _vkManager->beginImGuiFrame();
+
+    static bool showPerf = true;
+    if (showPerf) {
+        ImGui::SetNextWindowSize(ImVec2(380, 220), ImGuiCond_FirstUseEver);
+        ImGui::Begin("Performance", &showPerf);
+        ImGui::Text("Frame time: %.2f ms  (%.1f FPS)", g_FrameTimeMs, g_FPS);
+        static float history[120] = {};
+        static int idx = 0;
+        history[idx] = g_FrameTimeMs; idx = (idx + 1) % IM_ARRAYSIZE(history);
+        ImGui::PlotLines("Frametime (ms)", history, IM_ARRAYSIZE(history), idx, nullptr, 0.0f, 50.0f, ImVec2(-1, 60));
+        ImGui::End();
+    }
+
+    ImGui::Render();
+}
+
+void UISystem::LateUpdate(float deltaTime) {
+    (void)deltaTime;
+}
+

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -2,6 +2,9 @@
 #include <stb_image.h>
 #include <glm/gtx/hash.hpp>
 #include <filesystem>
+#include <imgui.h>
+#include <backends/imgui_impl_glfw.h>
+#include <backends/imgui_impl_vulkan.h>
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
@@ -33,6 +36,7 @@ NNE::Systems::VulkanManager::VulkanManager()
     graphicsPipeline = VK_NULL_HANDLE;
     commandPool = VK_NULL_HANDLE;
     descriptorPool = VK_NULL_HANDLE;
+    imguiPool = VK_NULL_HANDLE;
     descriptorSetLayout = VK_NULL_HANDLE;
     depthImage = VK_NULL_HANDLE;
     depthImageMemory = VK_NULL_HANDLE;
@@ -83,6 +87,7 @@ void NNE::Systems::VulkanManager::initVulkan()
     createDepthResources();         // 📏 Créer une image de profondeur
 
     createFramebuffers();           // 🖼 Associer toutes les ressources au framebuffer
+    initImGui();
 }
 
 
@@ -802,6 +807,90 @@ void NNE::Systems::VulkanManager::createFramebuffers()
     }
 }
 
+void NNE::Systems::VulkanManager::initImGui()
+{
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+    io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
+    ImGui::StyleColorsDark();
+    ImGuiStyle& style = ImGui::GetStyle();
+    if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
+        style.WindowRounding = 0.0f;
+        style.Colors[ImGuiCol_WindowBg].w = 1.0f;
+    }
+
+    VkDescriptorPoolSize pool_sizes[] = {
+        { VK_DESCRIPTOR_TYPE_SAMPLER, 1000 },
+        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1000 },
+        { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1000 },
+        { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1000 },
+        { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1000 },
+        { VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1000 },
+        { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1000 },
+        { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1000 },
+        { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1000 },
+        { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1000 },
+        { VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1000 }
+    };
+    VkDescriptorPoolCreateInfo pool_info{};
+    pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    pool_info.maxSets = 1000 * (uint32_t)std::size(pool_sizes);
+    pool_info.poolSizeCount = (uint32_t)std::size(pool_sizes);
+    pool_info.pPoolSizes = pool_sizes;
+    vkCreateDescriptorPool(device, &pool_info, nullptr, &imguiPool);
+
+    ImGui_ImplGlfw_InitForVulkan(window, true);
+
+    QueueFamilyIndices indices = findQueueFamilies(physicalDevice);
+    ImGui_ImplVulkan_InitInfo init_info{};
+    init_info.Instance = instance;
+    init_info.PhysicalDevice = physicalDevice;
+    init_info.Device = device;
+    init_info.QueueFamily = indices.graphicsFamily.value();
+    init_info.Queue = graphicsQueue;
+    init_info.DescriptorPool = imguiPool;
+    init_info.MinImageCount = static_cast<uint32_t>(swapChainImages.size());
+    init_info.ImageCount = static_cast<uint32_t>(swapChainImages.size());
+    init_info.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+    init_info.CheckVkResultFn = [](VkResult err) {
+        if (err != VK_SUCCESS) {
+            throw std::runtime_error("ImGui Vulkan backend error");
+        }
+    };
+    ImGui_ImplVulkan_Init(&init_info, renderPass);
+
+    VkCommandBuffer cmd = beginSingleTimeCommands();
+    ImGui_ImplVulkan_CreateFontsTexture(cmd);
+    endSingleTimeCommands(cmd);
+    ImGui_ImplVulkan_DestroyFontUploadObjects();
+}
+
+void NNE::Systems::VulkanManager::beginImGuiFrame()
+{
+    ImGui_ImplVulkan_NewFrame();
+    ImGui_ImplGlfw_NewFrame();
+    ImGui::NewFrame();
+}
+
+void NNE::Systems::VulkanManager::renderImGui(VkCommandBuffer commandBuffer)
+{
+    ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), commandBuffer);
+}
+
+void NNE::Systems::VulkanManager::cleanupImGui()
+{
+    ImGui_ImplVulkan_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext();
+    if (imguiPool != VK_NULL_HANDLE) {
+        vkDestroyDescriptorPool(device, imguiPool, nullptr);
+        imguiPool = VK_NULL_HANDLE;
+    }
+}
+
 void NNE::Systems::VulkanManager::createCommandPool()
 {
     QueueFamilyIndices queueFamilyIndices = findQueueFamilies(physicalDevice);
@@ -945,6 +1034,7 @@ void NNE::Systems::VulkanManager::recordCommandBuffer(VkCommandBuffer commandBuf
         //std::cout << "Rendering " << mesh->getIndexCount() << " indices from offset " << mesh->getIndexOffset() << std::endl;
     }
 
+    renderImGui(commandBuffer);
     vkCmdEndRenderPass(commandBuffer);
     if (vkEndCommandBuffer(commandBuffer) != VK_SUCCESS) {
         throw std::runtime_error("❌ Erreur : Échec de la finalisation du command buffer !");
@@ -1154,6 +1244,11 @@ void NNE::Systems::VulkanManager::drawFrame(const std::vector<std::pair<NNE::Com
         presentInfo.pImageIndices = &imageIndex;
 
         result = vkQueuePresentKHR(presentQueue, &presentInfo);
+
+        if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
+            ImGui::UpdatePlatformWindows();
+            ImGui::RenderPlatformWindowsDefault();
+        }
 
         if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR || framebufferResized) {
             framebufferResized = false;
@@ -1718,6 +1813,8 @@ void NNE::Systems::VulkanManager::CleanUp()
     if (device == VK_NULL_HANDLE) return;
 
     vkDeviceWaitIdle(device);
+
+    cleanupImGui();
 
     for (NNE::Component::Render::MeshComponent* mesh : loadedMeshes) {
         if (mesh) {


### PR DESCRIPTION
## Summary
- Centralize ImGui logic into a new UISystem that builds the performance window each frame
- Register UISystem before the render system so ImGui draw data is ready when Vulkan rendering occurs
- Expose beginImGuiFrame and renderImGui helpers on VulkanManager to support UISystem
