### PR TITLE
Refactor namespace usage and fix includes

### DIFF
--- a/src/include/Application.h
+++ b/src/include/Application.h
@@ -2,23 +2,7 @@
 #include <iostream>
 #include <vector>
 #include <map>
-#include "AEntity.h"
-#include "AComponent.h"
-#include "MeshComponent.h"
-#include "TransformComponent.h"
-#include "CameraComponent.h"
-#include "VulkanManager.h"
-#include "PhysicsSystem.h"
-#include "RenderSystem.h"
-//#include "UISystem.h"
-#include "InputSystem.h"
-#include "ScriptSystem.h"
-#include "PlaneCollider.h"
-#include "BoxColliderComponent.h"
-#include "RigidbodyComponent.h"
-#include "InputManager.h"
-#include "ISystem.h"
-#include "SystemManager.h"
+#include <unordered_map>
 
 namespace NNE { class AEntity; }
 namespace JPH { class BodyID; }
@@ -26,15 +10,16 @@ namespace JPH { class BodyID; }
 namespace NNE::Component::Physics { class ColliderComponent; }
 
 namespace NNE::Systems {
-    class VulkanManager;
-    class PhysicsSystem;
-    class RenderSystem;
-    class UISystem;
-    class InputSystem;
-    class ScriptSystem;
-    class ISystem;
-        class Application
-        {
+class VulkanManager;
+class PhysicsSystem;
+class RenderSystem;
+class UISystem;
+class InputSystem;
+class ScriptSystem;
+class ISystem;
+
+class Application
+{
         protected:
 
                 std::map<int, int> _link;
@@ -154,7 +139,7 @@ namespace NNE::Systems {
                 void UnregisterCollider(JPH::BodyID id) {
                         colliderMap.erase(id);
                 }
-        };
+};
 }
 
 

--- a/src/include/ColliderComponent.h
+++ b/src/include/ColliderComponent.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "AComponent.h"
-#include "AEntity.h"
 #include <Jolt/Jolt.h>
 #include <Jolt/Physics/Collision/Shape/Shape.h>
 

--- a/src/include/TransformComponent.h
+++ b/src/include/TransformComponent.h
@@ -2,6 +2,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include "AComponent.h"
+#include <algorithm>
 #include <iostream>
 #include <vector>
 

--- a/src/src/AScene.cpp
+++ b/src/src/AScene.cpp
@@ -4,8 +4,7 @@
 #include <sstream>
 #include <iomanip>
 #include <cstdio>
-
-using namespace NNE;
+#include <glm/glm.hpp>
 
 /**
  * <summary>
@@ -28,6 +27,8 @@ static glm::vec3 ParseVec3(const std::string& data)
     std::sscanf(data.c_str(), "[%f,%f,%f]", &v.x, &v.y, &v.z);
     return v;
 }
+
+namespace NNE {
 
 /**
  * <summary>
@@ -166,4 +167,6 @@ bool AScene::Load(const std::string& path)
 
     return true;
 }
+
+} // namespace NNE
 

--- a/src/src/Application.cpp
+++ b/src/src/Application.cpp
@@ -2,7 +2,14 @@
 #include "SystemManager.h"
 #include "PerformanceMetrics.h"
 #include <algorithm>
+#include <chrono>
+#include "VulkanManager.h"
+#include "PhysicsSystem.h"
+#include "RenderSystem.h"
 #include "UISystem.h"
+#include "InputSystem.h"
+#include "ScriptSystem.h"
+#include "InputManager.h"
 
 std::clock_t lastFrameTime;
 NNE::Systems::Application* NNE::Systems::Application::Instance = nullptr;

--- a/src/src/InputSystem.cpp
+++ b/src/src/InputSystem.cpp
@@ -1,6 +1,6 @@
 #include "InputSystem.h"
 
-using namespace NNE::Systems;
+namespace NNE::Systems {
 
 /**
  * <summary>
@@ -47,3 +47,4 @@ void InputSystem::RegisterComponent(NNE::Component::AComponent* component)
     }
 }
 
+} // namespace NNE::Systems

--- a/src/src/RenderSystem.cpp
+++ b/src/src/RenderSystem.cpp
@@ -2,7 +2,7 @@
 #include "VulkanManager.h"
 #include "AComponent.h"
 
-using namespace NNE::Systems;
+namespace NNE::Systems {
 
 /**
  * <summary>
@@ -75,4 +75,6 @@ const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Compone
 {
     return _renderObjects;
 }
+
+} // namespace NNE::Systems
 

--- a/src/src/ScriptSystem.cpp
+++ b/src/src/ScriptSystem.cpp
@@ -1,6 +1,6 @@
 #include "ScriptSystem.h"
 
-using namespace NNE::Systems;
+namespace NNE::Systems {
 
 /**
  * <summary>
@@ -40,3 +40,5 @@ void ScriptSystem::RegisterComponent(NNE::Component::AComponent* component)
         _components.push_back(mono);
     }
 }
+
+} // namespace NNE::Systems

--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -4,8 +4,7 @@
 #include <imgui.h>
 #include "Application.h"
 
-using namespace NNE::Systems;
-using namespace NNE;
+namespace NNE::Systems {
 
 UISystem::UISystem(VulkanManager* manager) : _vkManager(manager) {}
 
@@ -13,8 +12,7 @@ void UISystem::Start() {
     if (_vkManager) {
         _vkManager->initImGui();
     }
-
-	_app = Application::GetInstance();
+    _app = Application::GetInstance();
 }
 
 void UISystem::Update(float deltaTime) {
@@ -33,25 +31,24 @@ void UISystem::Update(float deltaTime) {
         ImGui::SetNextWindowSize(ImVec2(800, 600), ImGuiCond_Appearing);
         ImGui::Begin("Performance", &showPerf);
 
-		io.FontGlobalScale = 1.3f;
+        io.FontGlobalScale = 1.3f;
 
         ImGui::Text("Frame time: %.2f ms  (%.1f FPS)", g_FrameTimeMs, g_FPS);
 
         static float history[120] = {};
         static int idx = 0;
-        history[idx] = g_FrameTimeMs; idx = (idx + 1) % IM_ARRAYSIZE(history);
+        history[idx] = g_FrameTimeMs;
+        idx = (idx + 1) % IM_ARRAYSIZE(history);
         ImGui::PlotLines("Frametime (ms)", history, IM_ARRAYSIZE(history), idx, nullptr, 0.0f, 50.0f, ImVec2(-1, 80));
 
         ImGui::End();
         ImGui::Begin("Entities", &showPerf);
 
-        for each(AEntity* var in _app->_entities)
-        {
-            ImGui::Text("Entity : %d", var->GetName());
+        for (NNE::AEntity* entity : _app->_entities) {
+            ImGui::Text("Entity : %d", entity->GetName());
         }
 
         ImGui::End();
-
     }
 
     ImGui::Render();
@@ -60,4 +57,6 @@ void UISystem::Update(float deltaTime) {
 void UISystem::LateUpdate(float deltaTime) {
     (void)deltaTime;
 }
+
+} // namespace NNE::Systems
 


### PR DESCRIPTION
## Summary
- add missing `<algorithm>` include for TransformComponent
- remove `using namespace` directives in systems and wrap implementations in explicit namespaces
- standardize UI system loop and include direct glm dependency for scene serialization
- replace heavy project includes in Application with forward declarations and drop unused collider dependency to resolve circular includes
