### PR TITLE
Refactor namespace usage and fix includes

### DIFF
--- a/examples/src/Main.cpp
+++ b/examples/src/Main.cpp
@@ -1,4 +1,9 @@
 #include "Application.h"
+#include "TransformComponent.h"
+#include "BoxColliderComponent.h"
+#include "RigidbodyComponent.h"
+#include "MeshComponent.h"
+#include "CameraComponent.h"
 #include "../include/PlayerController.h"
 
 int main() {

--- a/src/include/Application.h
+++ b/src/include/Application.h
@@ -2,39 +2,25 @@
 #include <iostream>
 #include <vector>
 #include <map>
-#include "AEntity.h"
-#include "AComponent.h"
-#include "MeshComponent.h"
-#include "TransformComponent.h"
-#include "CameraComponent.h"
-#include "VulkanManager.h"
-#include "PhysicsSystem.h"
-#include "RenderSystem.h"
-//#include "UISystem.h"
-#include "InputSystem.h"
-#include "ScriptSystem.h"
-#include "PlaneCollider.h"
-#include "BoxColliderComponent.h"
-#include "RigidbodyComponent.h"
-#include "InputManager.h"
-#include "ISystem.h"
-#include "SystemManager.h"
+#include <Jolt/Jolt.h>
+#include <Jolt/Physics/Body/BodyID.h>
+#include <unordered_map>
 
 namespace NNE { class AEntity; }
-namespace JPH { class BodyID; }
 
 namespace NNE::Component::Physics { class ColliderComponent; }
 
 namespace NNE::Systems {
-    class VulkanManager;
-    class PhysicsSystem;
-    class RenderSystem;
-    class UISystem;
-    class InputSystem;
-    class ScriptSystem;
-    class ISystem;
-        class Application
-        {
+class VulkanManager;
+class PhysicsSystem;
+class RenderSystem;
+class UISystem;
+class InputSystem;
+class ScriptSystem;
+class ISystem;
+
+class Application
+{
         protected:
 
                 std::map<int, int> _link;
@@ -154,7 +140,7 @@ namespace NNE::Systems {
                 void UnregisterCollider(JPH::BodyID id) {
                         colliderMap.erase(id);
                 }
-        };
+};
 }
 
 

--- a/src/include/ColliderComponent.h
+++ b/src/include/ColliderComponent.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "AComponent.h"
-#include "AEntity.h"
 #include <Jolt/Jolt.h>
 #include <Jolt/Physics/Collision/Shape/Shape.h>
 

--- a/src/include/TransformComponent.h
+++ b/src/include/TransformComponent.h
@@ -2,6 +2,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include "AComponent.h"
+#include <algorithm>
 #include <iostream>
 #include <vector>
 

--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -21,8 +21,6 @@
 
 #define NOMINMAX //Necessary for ::Max()
 #define VK_USE_PLATFORM_WIN32_KHR
-#define VK_KHR_surface
-#define VK_KHR_win32_surface
 #define GLFW_INCLUDE_VULKAN
 #define GLM_FORCE_DEFAULT_ALIGNED_GENTYPES
 #define STB_IMAGE_IMPLEMENTATION
@@ -33,9 +31,9 @@
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
-#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/hash.hpp>
 #include <chrono>
 

--- a/src/src/AScene.cpp
+++ b/src/src/AScene.cpp
@@ -4,8 +4,7 @@
 #include <sstream>
 #include <iomanip>
 #include <cstdio>
-
-using namespace NNE;
+#include <glm/glm.hpp>
 
 /**
  * <summary>
@@ -28,6 +27,8 @@ static glm::vec3 ParseVec3(const std::string& data)
     std::sscanf(data.c_str(), "[%f,%f,%f]", &v.x, &v.y, &v.z);
     return v;
 }
+
+namespace NNE {
 
 /**
  * <summary>
@@ -166,4 +167,6 @@ bool AScene::Load(const std::string& path)
 
     return true;
 }
+
+} // namespace NNE
 

--- a/src/src/Application.cpp
+++ b/src/src/Application.cpp
@@ -2,7 +2,14 @@
 #include "SystemManager.h"
 #include "PerformanceMetrics.h"
 #include <algorithm>
+#include <chrono>
+#include "VulkanManager.h"
+#include "PhysicsSystem.h"
+#include "RenderSystem.h"
 #include "UISystem.h"
+#include "InputSystem.h"
+#include "ScriptSystem.h"
+#include "InputManager.h"
 
 std::clock_t lastFrameTime;
 NNE::Systems::Application* NNE::Systems::Application::Instance = nullptr;

--- a/src/src/BoxColliderComponent.cpp
+++ b/src/src/BoxColliderComponent.cpp
@@ -1,6 +1,9 @@
 #include "BoxColliderComponent.h"
+#include <Jolt/Jolt.h>
 #include <Jolt/Physics/Collision/Shape/BoxShape.h>
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
+#include <Jolt/Physics/Body/BodyInterface.h>
+#include "PhysicsSystem.h"
 #include "Application.h"
 
 /**

--- a/src/src/ColliderComponent.cpp
+++ b/src/src/ColliderComponent.cpp
@@ -1,5 +1,7 @@
 #include "ColliderComponent.h"
 #include "MonoComponent.h"
+#include "AEntity.h"
+#include <vector>
 
 
 /**
@@ -11,12 +13,11 @@ void NNE::Component::Physics::ColliderComponent::OnHit(ColliderComponent* other)
 {
         std::vector<NNE::Component::MonoComponent*> list = _entity->GetComponents<NNE::Component::MonoComponent>();
 
-	if (!list.empty()) {
-                for each (NNE::Component::MonoComponent * comp in list)
-                {
+        if (!list.empty()) {
+                for (NNE::Component::MonoComponent* comp : list) {
                         comp->OnHit(other);
                 }
-	}
+        }
 	
 }
 
@@ -29,10 +30,9 @@ void NNE::Component::Physics::ColliderComponent::OnTriggerHit(ColliderComponent*
 {
         std::vector<NNE::Component::MonoComponent*> list = _entity->GetComponents<NNE::Component::MonoComponent>();
 
-	if (!list.empty()) {
-                for each (NNE::Component::MonoComponent * comp in list)
-                {
+        if (!list.empty()) {
+                for (NNE::Component::MonoComponent* comp : list) {
                         comp->OnTriggerHit(other);
                 }
-	}
+        }
 }

--- a/src/src/InputSystem.cpp
+++ b/src/src/InputSystem.cpp
@@ -1,6 +1,6 @@
 #include "InputSystem.h"
 
-using namespace NNE::Systems;
+namespace NNE::Systems {
 
 /**
  * <summary>
@@ -47,3 +47,4 @@ void InputSystem::RegisterComponent(NNE::Component::AComponent* component)
     }
 }
 
+} // namespace NNE::Systems

--- a/src/src/PhysicsSystem.cpp
+++ b/src/src/PhysicsSystem.cpp
@@ -3,6 +3,8 @@
 #include "ColliderComponent.h"
 #include "RigidbodyComponent.h"
 #include "TransformComponent.h"
+#include "AEntity.h"
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/euler_angles.hpp>
 

--- a/src/src/RenderSystem.cpp
+++ b/src/src/RenderSystem.cpp
@@ -2,7 +2,7 @@
 #include "VulkanManager.h"
 #include "AComponent.h"
 
-using namespace NNE::Systems;
+namespace NNE::Systems {
 
 /**
  * <summary>
@@ -75,4 +75,6 @@ const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Compone
 {
     return _renderObjects;
 }
+
+} // namespace NNE::Systems
 

--- a/src/src/RigidbodyComponent.cpp
+++ b/src/src/RigidbodyComponent.cpp
@@ -1,7 +1,11 @@
 #include "RigidbodyComponent.h"
-#include "Application.h"
 #include "TransformComponent.h"
+#include <Jolt/Jolt.h>
+#include "PhysicsSystem.h"
+#include "Application.h"
+#include "AEntity.h"
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
+#include <Jolt/Physics/Body/BodyInterface.h>
 
 namespace NNE::Component::Physics {
 

--- a/src/src/ScriptSystem.cpp
+++ b/src/src/ScriptSystem.cpp
@@ -1,6 +1,6 @@
 #include "ScriptSystem.h"
 
-using namespace NNE::Systems;
+namespace NNE::Systems {
 
 /**
  * <summary>
@@ -40,3 +40,5 @@ void ScriptSystem::RegisterComponent(NNE::Component::AComponent* component)
         _components.push_back(mono);
     }
 }
+
+} // namespace NNE::Systems

--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -4,8 +4,7 @@
 #include <imgui.h>
 #include "Application.h"
 
-using namespace NNE::Systems;
-using namespace NNE;
+namespace NNE::Systems {
 
 UISystem::UISystem(VulkanManager* manager) : _vkManager(manager) {}
 
@@ -13,8 +12,7 @@ void UISystem::Start() {
     if (_vkManager) {
         _vkManager->initImGui();
     }
-
-	_app = Application::GetInstance();
+    _app = Application::GetInstance();
 }
 
 void UISystem::Update(float deltaTime) {
@@ -33,25 +31,24 @@ void UISystem::Update(float deltaTime) {
         ImGui::SetNextWindowSize(ImVec2(800, 600), ImGuiCond_Appearing);
         ImGui::Begin("Performance", &showPerf);
 
-		io.FontGlobalScale = 1.3f;
+        io.FontGlobalScale = 1.3f;
 
         ImGui::Text("Frame time: %.2f ms  (%.1f FPS)", g_FrameTimeMs, g_FPS);
 
         static float history[120] = {};
         static int idx = 0;
-        history[idx] = g_FrameTimeMs; idx = (idx + 1) % IM_ARRAYSIZE(history);
+        history[idx] = g_FrameTimeMs;
+        idx = (idx + 1) % IM_ARRAYSIZE(history);
         ImGui::PlotLines("Frametime (ms)", history, IM_ARRAYSIZE(history), idx, nullptr, 0.0f, 50.0f, ImVec2(-1, 80));
 
         ImGui::End();
         ImGui::Begin("Entities", &showPerf);
 
-        for each(AEntity* var in _app->_entities)
-        {
-            ImGui::Text("Entity : %d", var->GetName());
+        for (NNE::AEntity* entity : _app->_entities) {
+            ImGui::Text("Entity : %d", entity->GetName());
         }
 
         ImGui::End();
-
     }
 
     ImGui::Render();
@@ -60,4 +57,6 @@ void UISystem::Update(float deltaTime) {
 void UISystem::LateUpdate(float deltaTime) {
     (void)deltaTime;
 }
+
+} // namespace NNE::Systems
 

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -1,6 +1,5 @@
 #include "VulkanManager.h"
 #include <stb_image.h>
-#include <glm/gtx/hash.hpp>
 #include <filesystem>
 #include <imgui.h>
 #include <backends/imgui_impl_glfw.h>

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -7,6 +7,7 @@
 #include "AComponent.h"
 #include "AScene.h"
 #include "Application.h"
+#include <glm/gtc/epsilon.hpp>
 #include <cstdio>
 
 static void test_default_transform()


### PR DESCRIPTION
## Summary
- order BodyID include ahead of unordered_map to expose hash specialization
- add missing Jolt activation state and physics headers for body creation
- replace non-standard `for each` loops with standard range-based iteration and move GLM experimental define before headers
- ensure Jolt core header precedes physics headers and remove obsolete activation include
- include entity definitions in physics system implementation
- include engine components in example and add GLM epsilon header for tests

## Testing
- `g++ -std=c++17 tests/test_main.cpp -Isrc/include -c` *(fails: glm/glm.hpp: No such file or directory)*
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glfw3")*


------
https://chatgpt.com/codex/tasks/task_e_68ae24d92d4c832a8729f14f1214656e