### PR TITLE
Fix Vulkan logical device feature setup

### DIFF
--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -171,10 +171,11 @@ namespace NNE::Systems {
                 VkDescriptorPool descriptorPool;
                 VkDescriptorPool imguiPool;
 
-		VkImage depthImage;
-		VkDeviceMemory depthImageMemory;
-		VkImageView depthImageView;
-		VkSampleCountFlagBits msaaSamples = VK_SAMPLE_COUNT_8_BIT;
+                VkImage depthImage;
+                VkDeviceMemory depthImageMemory;
+                VkImageView depthImageView;
+                VkSampleCountFlagBits msaaSamples = VK_SAMPLE_COUNT_8_BIT;
+                bool supportsRenderToSingleSampled = false;
 
 	public :
             NNE::Component::Render::CameraComponent* activeCamera = nullptr;
@@ -541,6 +542,7 @@ namespace NNE::Systems {
                  * </summary>
                  */
                 bool checkDeviceExtensionSupport(VkPhysicalDevice device);
+                bool hasExtension(VkPhysicalDevice device, const char* extensionName);
 
                 /**
                  * <summary>


### PR DESCRIPTION
## Summary
- Detect VK_EXT_multisampled_render_to_single_sampled support per device and enable the extension only when available
- Drop the extension from the required list so devices lacking it can still be selected

## Testing
- ⚠️ `cmake ..` (failed: Could not find a package configuration file provided by "glfw3")
- ⚠️ `apt-get install -y libglfw3-dev` (failed: Unable to locate package libglfw3-dev)


------
https://chatgpt.com/codex/tasks/task_e_68b192a0bab0832ab9b2d6e19d7a2399