### PR TITLE
Fix per-mesh descriptor sets and MSAA configuration

### DIFF
--- a/src/include/MeshComponent.h
+++ b/src/include/MeshComponent.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "AComponent.h"
 #include <string>
+#include <vector>
 #include <vulkan/vulkan.h>
 
 namespace NNE::Component::Render {
@@ -33,6 +34,7 @@ namespace NNE::Component::Render {
         VkDeviceMemory textureImageMemory = VK_NULL_HANDLE;
         VkImageView textureImageView = VK_NULL_HANDLE;
         VkSampler textureSampler = VK_NULL_HANDLE;
+        std::vector<VkDescriptorSet> descriptorSets;
 
         /**
          * <summary>

--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -170,7 +170,6 @@ namespace NNE::Systems {
 
                 VkDescriptorPool descriptorPool;
                 VkDescriptorPool imguiPool;
-                std::vector<VkDescriptorSet> descriptorSets;
 
 		VkImage depthImage;
 		VkDeviceMemory depthImageMemory;


### PR DESCRIPTION
## Summary
- store descriptor sets on each mesh instead of globally
- size descriptor pool for all meshes and allocate per-frame sets
- bind per-mesh descriptor sets during draws to prevent updates while recording

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "glfw3")*


------
https://chatgpt.com/codex/tasks/task_e_68b19cec8258832a8da20a90a5da4157