### PR TITLE
Fix physics system axis conversion

### DIFF
--- a/examples/src/Main.cpp
+++ b/examples/src/Main.cpp
@@ -24,21 +24,21 @@ int main() {
 
     NNE::AEntity* floor = app.CreateEntity();
 	floor->SetName("Floor");
-    NNE::Component::Physics::PlaneCollider const* PC = floor->AddComponent<NNE::Component::Physics::PlaneCollider>(glm::vec3(0, 1, 0), 10.0f);
+    NNE::Component::Physics::PlaneCollider const* PC = floor->AddComponent<NNE::Component::Physics::PlaneCollider>(glm::vec3(0, 0, 1), 10.0f);
     NNE::Component::TransformComponent* TCfloor = floor->GetComponent<NNE::Component::TransformComponent>();
     NNE::Component::Physics::BoxColliderComponent const* BCFloor = floor->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(100.0f, 0.50f, 100.0f));
     NNE::Component::Physics::RigidbodyComponent const* RBCFloor = floor->AddComponent<NNE::Component::Physics::RigidbodyComponent>(10.0f, true);
     NNE::Component::Render::MeshComponent* MFC = floor->AddComponent<NNE::Component::Render::MeshComponent>();
 	MFC->SetPrimitive(NNE::Component::Render::PrimitiveType::CUBE);
 	MFC->SetTexturePath("../assets/textures/viking_room.png");
-	TCfloor->position = glm::vec3(0.0f, -30.0f, 0.0f);
-	TCfloor->rotation = glm::vec3(90.0f, 0.0f, 0.0f);
+        TCfloor->position = glm::vec3(0.0f, 0.0f, 0.0f);
+        TCfloor->rotation = glm::vec3(0.0f, 0.0f, 0.0f);
 	TCfloor->scale = glm::vec3(100.0f, 0.5f, 100.0f);
 
     NNE::AEntity* entity = app.CreateEntity();
     NNE::Component::Render::MeshComponent* MC = entity->AddComponent<NNE::Component::Render::MeshComponent>();
     NNE::Component::TransformComponent* TC = entity->GetComponent<NNE::Component::TransformComponent>();
-    TC->position = glm::vec3(0.0f, 5.0f, 0.0f);
+    TC->position = glm::vec3(0.0f, 0.0f, 5.0f);
     NNE::Component::Physics::BoxColliderComponent const* BCC = entity->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(1.0f, 1.0f, 1.0f));
     NNE::Component::Physics::RigidbodyComponent const* RBC = entity->AddComponent<NNE::Component::Physics::RigidbodyComponent>( 0.1f, false);
 	
@@ -54,7 +54,7 @@ int main() {
     PlayerController const* PlayerC = player->AddComponent<PlayerController>();
 
 
-	TCplayer->position = glm::vec3(0.0f, 2.0f, 0.0f);
+        TCplayer->position = glm::vec3(0.0f, 0.0f, 2.0f);
 
     NNE::AEntity* camera = app.CreateEntity();
     NNE::Component::Render::CameraComponent* CC = camera->AddComponent<NNE::Component::Render::CameraComponent>();
@@ -63,8 +63,8 @@ int main() {
 	TC2->SetParent(TCplayer);
 
 	CC->SetPerspective(55.0f, 16.0f / 9.0f, 0.1f, 500.0f);	
-	TC2->position = glm::vec3(0.0f, 2.0f, 0.0f);
-	TC2->rotation = glm::vec3(90.0f, 0.0f, 0.0f);
+        TC2->position = glm::vec3(0.0f, 0.0f, 2.0f);
+        TC2->rotation = glm::vec3(0.0f, 0.0f, 0.0f);
         app.VKManager->activeCamera = CC;
 
     app.Init();


### PR DESCRIPTION
## Summary
- centralize Jolt-to-engine transform conversion in helper functions
- orient example floor, player, and camera for Z-up/-Y-forward world
