### PR TITLE
Refactor tests with simple runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_custom_command(TARGET GameTemplate POST_BUILD
 
 # ---------------- Tests ----------------
 enable_testing()
-add_executable(UnitTests tests/test_main.cpp)
+file(GLOB TEST_SOURCES tests/*.cpp)
+add_executable(UnitTests ${TEST_SOURCES})
 target_link_libraries(UnitTests PRIVATE NNEngine)
 add_test(NAME UnitTests COMMAND UnitTests)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -7,33 +7,43 @@
 #include "TransformComponent.h"
 #include "PlaneCollider.h"
 #include "RigidbodyComponent.h"
-#include <cassert>
 #include <cstdio>
 #include <glm/gtc/epsilon.hpp>
 #include <iostream>
+#include <stdexcept>
+#include <vector>
+
+// Simple assertion macro that throws on failure so tests can continue
+#define EXPECT_TRUE(cond)                                                        \
+  do {                                                                          \
+    if (!(cond))                                                                \
+      throw std::runtime_error("Expectation failed: " #cond);                  \
+  } while (0)
 
 static void test_default_transform() {
   NNE::Component::TransformComponent t;
-  assert(t.position == glm::vec3(0.0f));
-  assert(t.rotation == glm::vec3(0.0f));
-  assert(t.scale == glm::vec3(1.0f, 1.0f, 1.0f));
+  EXPECT_TRUE(t.position == glm::vec3(0.0f));
+  EXPECT_TRUE(t.rotation == glm::vec3(0.0f));
+  EXPECT_TRUE(t.scale == glm::vec3(1.0f, 1.0f, 1.0f));
 }
 
 static void test_parent_relationship() {
   NNE::Component::TransformComponent parent;
   NNE::Component::TransformComponent child;
   child.SetParent(&parent);
-  assert(child.parent == &parent);
-  assert(parent.children.size() == 1);
-  assert(parent.children[0] == &child);
+  EXPECT_TRUE(child.parent == &parent);
+  EXPECT_TRUE(parent.children.size() == 1);
+  EXPECT_TRUE(parent.children[0] == &child);
 }
 
 static void test_transform_directions() {
   NNE::Component::TransformComponent t;
   glm::vec3 forward = t.GetForward();
   glm::vec3 up = t.GetUp();
-  assert(glm::all(glm::epsilonEqual(forward, glm::vec3(0, 0, 1), 0.0001f)));
-  assert(glm::all(glm::epsilonEqual(up, glm::vec3(0, 1, 0), 0.0001f)));
+  EXPECT_TRUE(
+      glm::all(glm::epsilonEqual(forward, glm::vec3(0, 0, 1), 0.0001f)));
+  EXPECT_TRUE(
+      glm::all(glm::epsilonEqual(up, glm::vec3(0, 1, 0), 0.0001f)));
 }
 
 static void test_world_position() {
@@ -43,7 +53,7 @@ static void test_world_position() {
   child.position = glm::vec3(1.0f, 0.0f, 0.0f);
   child.SetParent(&parent);
   glm::vec3 worldPos = child.GetWorldPosition();
-  assert(glm::all(
+  EXPECT_TRUE(glm::all(
       glm::epsilonEqual(worldPos, glm::vec3(2.0f, 2.0f, 3.0f), 0.0001f)));
 }
 
@@ -51,25 +61,25 @@ static void test_mesh_component_paths() {
   NNE::Component::Render::MeshComponent m;
   m.SetModelPath("model.obj");
   m.SetTexturePath("texture.png");
-  assert(m.GetModelPath() == "model.obj");
-  assert(m.GetTexturePath() == "texture.png");
+  EXPECT_TRUE(m.GetModelPath() == "model.obj");
+  EXPECT_TRUE(m.GetTexturePath() == "texture.png");
 }
 
 static void test_camera_perspective() {
   NNE::Component::Render::CameraComponent c;
   c.SetPerspective(60.0f, 4.0f / 3.0f, 0.1f, 200.0f);
-  assert(c.GetFOV() == 60.0f);
-  assert(c.GetAspectRatio() == 4.0f / 3.0f);
-  assert(c.GetNearPlane() == 0.1f);
-  assert(c.GetFarPlane() == 200.0f);
+  EXPECT_TRUE(c.GetFOV() == 60.0f);
+  EXPECT_TRUE(c.GetAspectRatio() == 4.0f / 3.0f);
+  EXPECT_TRUE(c.GetNearPlane() == 0.1f);
+  EXPECT_TRUE(c.GetFarPlane() == 200.0f);
 }
 
 static void test_entity_component_management() {
   NNE::AEntity e;
   NNE::Component::Render::MeshComponent *mc =
       e.AddComponent<NNE::Component::Render::MeshComponent>();
-  assert(mc->GetEntity() == &e);
-  assert(e.GetComponent<NNE::Component::Render::MeshComponent>() == mc);
+  EXPECT_TRUE(mc->GetEntity() == &e);
+  EXPECT_TRUE(e.GetComponent<NNE::Component::Render::MeshComponent>() == mc);
 }
 
 static void test_get_components_multiple() {
@@ -77,16 +87,16 @@ static void test_get_components_multiple() {
   e.AddComponent<NNE::Component::Render::MeshComponent>();
   e.AddComponent<NNE::Component::Render::MeshComponent>();
   auto meshes = e.GetComponents<NNE::Component::Render::MeshComponent>();
-  assert(meshes.size() == 2);
+  EXPECT_TRUE(meshes.size() == 2);
   for (auto *m : meshes) {
-    assert(m->GetEntity() == &e);
+    EXPECT_TRUE(m->GetEntity() == &e);
   }
 }
 
 static void test_application_id_increment() {
   int id1 = NNE::Systems::Application::GetInstance()->GenerateID();
   int id2 = NNE::Systems::Application::GetInstance()->GenerateID();
-  assert(id2 == id1 + 1);
+  EXPECT_TRUE(id2 == id1 + 1);
 }
 
 static void test_model_matrix_translation() {
@@ -94,8 +104,8 @@ static void test_model_matrix_translation() {
   t.position = glm::vec3(1.0f, 2.0f, 3.0f);
   glm::mat4 mat = t.getModelMatrix();
   glm::vec3 trans(mat[3]);
-  assert(
-      glm::all(glm::epsilonEqual(trans, glm::vec3(1.0f, 2.0f, 3.0f), 0.0001f)));
+  EXPECT_TRUE(glm::all(
+      glm::epsilonEqual(trans, glm::vec3(1.0f, 2.0f, 3.0f), 0.0001f)));
 }
 
 static void test_plane_collider_awake_creates_shape() {
@@ -103,7 +113,7 @@ static void test_plane_collider_awake_creates_shape() {
   auto *pc = e.AddComponent<NNE::Component::Physics::PlaneCollider>(
       glm::vec3(0.0f, 1.0f, 0.0f), 0.0f);
   pc->Awake();
-  assert(pc->GetShape().GetPtr() != nullptr);
+  EXPECT_TRUE(pc->GetShape().GetPtr() != nullptr);
 }
 
 static void test_rigidbody_awake_initializes_collider() {
@@ -112,7 +122,7 @@ static void test_rigidbody_awake_initializes_collider() {
   auto *pc = e.AddComponent<NNE::Component::Physics::PlaneCollider>(
       glm::vec3(0.0f, 1.0f, 0.0f), 0.0f);
   rb->Awake();
-  assert(pc->GetShape().GetPtr() != nullptr);
+  EXPECT_TRUE(pc->GetShape().GetPtr() != nullptr);
 }
 
 static void test_scene_serialization() {
@@ -131,27 +141,27 @@ static void test_scene_serialization() {
   scene.entities.push_back(e2);
 
   bool saved = scene.Save("test_scene.json");
-  assert(saved);
+  EXPECT_TRUE(saved);
 
   NNE::AScene loaded;
   bool loadedOk = loaded.Load("test_scene.json");
-  assert(loadedOk);
-  assert(loaded.entities.size() == 2);
+  EXPECT_TRUE(loadedOk);
+  EXPECT_TRUE(loaded.entities.size() == 2);
 
   auto *lt1 =
       loaded.entities[0]->GetComponent<NNE::Component::TransformComponent>();
   auto *lm1 =
       loaded.entities[0]->GetComponent<NNE::Component::Render::MeshComponent>();
-  assert(lt1 && lm1);
-  assert(glm::all(
+  EXPECT_TRUE(lt1 && lm1);
+  EXPECT_TRUE(glm::all(
       glm::epsilonEqual(lt1->position, glm::vec3(1.0f, 2.0f, 3.0f), 0.0001f)));
-  assert(lm1->GetModelPath() == "model1.obj");
-  assert(lm1->GetTexturePath() == "texture1.png");
+  EXPECT_TRUE(lm1->GetModelPath() == "model1.obj");
+  EXPECT_TRUE(lm1->GetTexturePath() == "texture1.png");
 
   auto *lt2 =
       loaded.entities[1]->GetComponent<NNE::Component::TransformComponent>();
-  assert(lt2);
-  assert(glm::all(
+  EXPECT_TRUE(lt2);
+  EXPECT_TRUE(glm::all(
       glm::epsilonEqual(lt2->position, glm::vec3(4.0f, 5.0f, 6.0f), 0.0001f)));
 
   std::remove("test_scene.json");
@@ -159,19 +169,43 @@ static void test_scene_serialization() {
 
 int main() {
   NNE::Systems::Application app;
-  test_application_id_increment();
-  test_default_transform();
-  test_parent_relationship();
-  test_transform_directions();
-  test_world_position();
-  test_model_matrix_translation();
-  test_scene_serialization();
-  test_mesh_component_paths();
-  test_camera_perspective();
-  test_entity_component_management();
-  test_get_components_multiple();
-  test_rigidbody_awake_initializes_collider();
-  test_plane_collider_awake_creates_shape();
-  std::cout << "All tests passed" << std::endl;
-  return 0;
+  struct TestCase {
+    const char *name;
+    void (*func)();
+  };
+  std::vector<TestCase> tests = {
+      {"application_id_increment", test_application_id_increment},
+      {"default_transform", test_default_transform},
+      {"parent_relationship", test_parent_relationship},
+      {"transform_directions", test_transform_directions},
+      {"world_position", test_world_position},
+      {"model_matrix_translation", test_model_matrix_translation},
+      {"scene_serialization", test_scene_serialization},
+      {"mesh_component_paths", test_mesh_component_paths},
+      {"camera_perspective", test_camera_perspective},
+      {"entity_component_management", test_entity_component_management},
+      {"get_components_multiple", test_get_components_multiple},
+      {"rigidbody_awake_initializes_collider",
+       test_rigidbody_awake_initializes_collider},
+      {"plane_collider_awake_creates_shape",
+       test_plane_collider_awake_creates_shape},
+  };
+
+  int failed = 0;
+  for (const auto &t : tests) {
+    try {
+      t.func();
+      std::cout << "[PASS] " << t.name << std::endl;
+    } catch (const std::exception &e) {
+      failed++;
+      std::cout << "[FAIL] " << t.name << ": " << e.what() << std::endl;
+    }
+  }
+
+  if (failed == 0) {
+    std::cout << "All tests passed" << std::endl;
+  } else {
+    std::cout << failed << " tests failed" << std::endl;
+  }
+  return failed == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- replace raw asserts with custom EXPECT macro for detailed output
- add minimal test harness printing per-test results
- glob test sources in CMake for easier segmentation

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "glfw3"...)*

------
https://chatgpt.com/codex/tasks/task_e_68b84914e37c832abc75d412a3e38c85