### PR TITLE
Recreate graphics pipeline on swapchain recreation

### DIFF
--- a/examples/src/Main.cpp
+++ b/examples/src/Main.cpp
@@ -25,7 +25,8 @@ int main() {
     NNE::AEntity* floor = app.CreateEntity();
 	floor->SetName("Floor");
     //NNE::Component::Physics::BoxColliderComponent const* PC = floor->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(100.0f, 0.5f, 100.0f));
-    NNE::Component::Physics::PlaneCollider const* PC = floor->AddComponent<NNE::Component::Physics::PlaneCollider>(glm::vec3(1.0f, 1.0f, 1.0f));
+    NNE::Component::Physics::PlaneCollider const* PC = floor->AddComponent<NNE::Component::Physics::PlaneCollider>(
+        glm::vec3(1.0f, 1.0f, 1.0f), 0.0f);
     NNE::Component::TransformComponent* TCfloor = floor->GetComponent<NNE::Component::TransformComponent>();    
     NNE::Component::Physics::RigidbodyComponent const* RBCFloor = floor->AddComponent<NNE::Component::Physics::RigidbodyComponent>(1.0f, false, glm::bvec3(1, 1, 1));
     NNE::Component::Render::MeshComponent* MFC = floor->AddComponent<NNE::Component::Render::MeshComponent>();

--- a/examples/src/Main.cpp
+++ b/examples/src/Main.cpp
@@ -26,9 +26,9 @@ int main() {
 	floor->SetName("Floor");
     //NNE::Component::Physics::BoxColliderComponent const* PC = floor->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(100.0f, 0.5f, 100.0f));
     NNE::Component::Physics::PlaneCollider const* PC = floor->AddComponent<NNE::Component::Physics::PlaneCollider>(
-        glm::vec3(1.0f, 1.0f, 1.0f), 0.0f);
+        glm::vec3(1.0f, 1.0f, 1.0f));
     NNE::Component::TransformComponent* TCfloor = floor->GetComponent<NNE::Component::TransformComponent>();    
-    NNE::Component::Physics::RigidbodyComponent const* RBCFloor = floor->AddComponent<NNE::Component::Physics::RigidbodyComponent>(1.0f, false, glm::bvec3(1, 1, 1));
+    NNE::Component::Physics::RigidbodyComponent const* RBCFloor = floor->AddComponent<NNE::Component::Physics::RigidbodyComponent>(1.0f, true);
     NNE::Component::Render::MeshComponent* MFC = floor->AddComponent<NNE::Component::Render::MeshComponent>();
 	MFC->SetPrimitive(NNE::Component::Render::PrimitiveType::CUBE);
 	MFC->SetTexturePath("../assets/textures/checker.png");
@@ -51,7 +51,7 @@ int main() {
     NNE::AEntity* player = app.CreateEntity();
     NNE::Component::TransformComponent* TCplayer = player->GetComponent<NNE::Component::TransformComponent>();
     NNE::Component::Physics::BoxColliderComponent const* BCCplayer = player->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(1.0f, 1.0f, 1.0f));
-    NNE::Component::Physics::RigidbodyComponent const* RBCplayer = player->AddComponent<NNE::Component::Physics::RigidbodyComponent>(1.0f, false);
+    NNE::Component::Physics::RigidbodyComponent const* RBCplayer = player->AddComponent<NNE::Component::Physics::RigidbodyComponent>(1.0f, false, glm::bvec3(0, 0, 0), glm::bvec3(1, 0, 1));
     PlayerController const* PlayerC = player->AddComponent<PlayerController>();
 
 

--- a/examples/src/Main.cpp
+++ b/examples/src/Main.cpp
@@ -24,9 +24,8 @@ int main() {
 
     NNE::AEntity* floor = app.CreateEntity();
 	floor->SetName("Floor");
-    //NNE::Component::Physics::BoxColliderComponent const* PC = floor->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(100.0f, 0.5f, 100.0f));
-    NNE::Component::Physics::PlaneCollider const* PC = floor->AddComponent<NNE::Component::Physics::PlaneCollider>(
-        glm::vec3(1.0f, 1.0f, 1.0f));
+    NNE::Component::Physics::BoxColliderComponent const* PC = floor->AddComponent<NNE::Component::Physics::BoxColliderComponent>(glm::vec3(100.0f, 0.5f, 100.0f));
+    //NNE::Component::Physics::PlaneCollider const* PC = floor->AddComponent<NNE::Component::Physics::PlaneCollider>(glm::vec3(1.0f, 1.0f, 1.0f));
     NNE::Component::TransformComponent* TCfloor = floor->GetComponent<NNE::Component::TransformComponent>();    
     NNE::Component::Physics::RigidbodyComponent const* RBCFloor = floor->AddComponent<NNE::Component::Physics::RigidbodyComponent>(1.0f, true);
     NNE::Component::Render::MeshComponent* MFC = floor->AddComponent<NNE::Component::Render::MeshComponent>();

--- a/src/include/RigidbodyComponent.h
+++ b/src/include/RigidbodyComponent.h
@@ -62,6 +62,12 @@ namespace NNE::Component::Physics {
         void SetLinearVelocity(glm::vec3 velocity);
         /**
          * <summary>
+         * Déplace un corps cinématique vers une nouvelle position.
+         * </summary>
+         */
+        void MoveKinematic(glm::vec3 position, float deltaTime);
+        /**
+         * <summary>
          * Obtient la vitesse linéaire actuelle.
          * </summary>
          */

--- a/src/include/RigidbodyComponent.h
+++ b/src/include/RigidbodyComponent.h
@@ -17,6 +17,8 @@ namespace NNE::Component::Physics {
         bool isKinematic;
         glm::bvec3 lockPosition;
         glm::bvec3 lockRotation;
+        glm::vec3 lastPosition;
+        glm::vec3 lastRotation;
 
     public:
         /**
@@ -65,7 +67,9 @@ namespace NNE::Component::Physics {
          * Déplace un corps cinématique vers une nouvelle position.
          * </summary>
          */
-        void MoveKinematic(glm::vec3 position, float deltaTime);
+
+        void MoveKinematic(glm::vec3 position, glm::vec3 rotation, float deltaTime);
+
         /**
          * <summary>
          * Obtient la vitesse linéaire actuelle.

--- a/src/src/PhysicsSystem.cpp
+++ b/src/src/PhysicsSystem.cpp
@@ -22,7 +22,7 @@ inline glm::vec3 ToEngineRotation(const JPH::Quat &rot) {
   return glm::degrees(glm::eulerAngles(q));
 }
 
-} // namespace
+} 
 
 class SimpleBroadPhaseLayerInterface final
     : public JPH::BroadPhaseLayerInterface {
@@ -211,4 +211,4 @@ void PhysicsSystem::ContactListenerImpl::OnContactAdded(
   }
 }
 
-} // namespace NNE::Systems
+} 

--- a/src/src/RigidbodyComponent.cpp
+++ b/src/src/RigidbodyComponent.cpp
@@ -64,6 +64,8 @@ void RigidbodyComponent::Awake() {
     JPH::EMotionType motionType = isKinematic ? JPH::EMotionType::Kinematic
         : JPH::EMotionType::Dynamic;
 
+    //JPH::EMotionType motionType = JPH::EMotionType::Dynamic;
+
 
     JPH::BodyCreationSettings bodySettings(
         collider->GetShape(),
@@ -93,6 +95,8 @@ void RigidbodyComponent::Awake() {
         bodySettings.mMassPropertiesOverride.mMass = 1.0f;
         bodySettings.mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity();
         bodySettings.mGravityFactor = 0.0f;
+		bodySettings.mUseManifoldReduction = false; // Important pour les kinematic		
+		
     }
 
     JPH::BodyInterface& bodyInterface = physicsSystem->GetBodyInterface();

--- a/src/src/RigidbodyComponent.cpp
+++ b/src/src/RigidbodyComponent.cpp
@@ -10,6 +10,7 @@
 #include <Jolt/Physics/Body/BodyInterface.h>
 #include <Jolt/Physics/Body/MassProperties.h>
 #include <imgui.h>
+#include <iostream>
 
 
 namespace NNE::Component::Physics {
@@ -59,6 +60,11 @@ void RigidbodyComponent::Awake() {
         collider->Awake();
         if (!collider->GetShape())
             return;
+    }
+
+    if (collider->IsTrigger()) {
+        std::cerr << "Collider on entity '" << GetEntity()->GetName()
+                  << "' is marked as trigger; dynamic bodies will pass through." << std::endl;
     }
 
     JPH::EMotionType motionType = isKinematic ? JPH::EMotionType::Kinematic
@@ -129,11 +135,30 @@ JPH::BodyID RigidbodyComponent::GetBodyID() const {
  * </summary>
  */
 void RigidbodyComponent::SetLinearVelocity(glm::vec3 velocity) {
-    
+
     auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
     auto& bodyInterface = physicsSystem->GetBodyInterface();
     if (!bodyID.IsInvalid()) {
         bodyInterface.SetLinearVelocity(bodyID, JPH::RVec3(velocity.x, velocity.y, velocity.z));
+    }
+}
+
+/**
+ * <summary>
+ * Déplace un corps cinématique vers une nouvelle position.
+ * </summary>
+ */
+void RigidbodyComponent::MoveKinematic(glm::vec3 position, float deltaTime) {
+    if (!isKinematic)
+        return;
+
+    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
+    auto& bodyInterface = physicsSystem->GetBodyInterface();
+    if (!bodyID.IsInvalid()) {
+        bodyInterface.MoveKinematic(bodyID,
+                                    JPH::RVec3(position.x, position.y, position.z),
+                                    JPH::Quat::sIdentity(),
+                                    deltaTime);
     }
 }
 

--- a/src/src/RigidbodyComponent.cpp
+++ b/src/src/RigidbodyComponent.cpp
@@ -9,6 +9,8 @@
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
 #include <Jolt/Physics/Body/BodyInterface.h>
 #include <Jolt/Physics/Body/MassProperties.h>
+#include <Jolt/Physics/Body/MotionProperties.h>
+#include <glm/gtc/quaternion.hpp>
 #include <imgui.h>
 #include <iostream>
 
@@ -28,7 +30,9 @@ RigidbodyComponent::RigidbodyComponent(float mass,
       mass(mass),
       isKinematic(kinematic),
       lockPosition(lockPosition),
-      lockRotation(lockRotation) {
+      lockRotation(lockRotation),
+      lastPosition(0.0f),
+      lastRotation(0.0f) {
 }
 
 /**
@@ -51,6 +55,10 @@ RigidbodyComponent::~RigidbodyComponent() {
 void RigidbodyComponent::Awake() {
     auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
     auto const* transform = GetEntity()->GetComponent<NNE::Component::TransformComponent>();
+    if (transform) {
+        lastPosition = transform->position;
+        lastRotation = transform->rotation;
+    }
     auto* collider = GetEntity()->GetComponent<NNE::Component::Physics::ColliderComponent>();
 
     if (!collider)
@@ -64,7 +72,10 @@ void RigidbodyComponent::Awake() {
 
     if (collider->IsTrigger()) {
         std::cerr << "Collider on entity '" << GetEntity()->GetName()
-                  << "' is marked as trigger; dynamic bodies will pass through." << std::endl;
+
+                  << "' is marked as trigger; forcing IsTrigger to false for physical collisions." << std::endl;
+        collider->SetTrigger(false);
+
     }
 
     JPH::EMotionType motionType = isKinematic ? JPH::EMotionType::Kinematic
@@ -91,9 +102,11 @@ void RigidbodyComponent::Awake() {
     bodySettings.mAllowedDOFs = allowed;
 
     if (!isKinematic && mass > 0.0f) {
+        JPH::MassProperties mp = collider->GetShape()->GetMassProperties();
+        mp.ScaleToMass(mass);
+        bodySettings.mMassPropertiesOverride = mp;
         bodySettings.mOverrideMassProperties = JPH::EOverrideMassProperties::MassAndInertiaProvided;
-        bodySettings.mMassPropertiesOverride.mMass = mass;
-        bodySettings.mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity();
+        bodySettings.mMotionQuality = JPH::EMotionQuality::LinearCast;
     }
 
     if (isKinematic) {
@@ -101,8 +114,8 @@ void RigidbodyComponent::Awake() {
         bodySettings.mMassPropertiesOverride.mMass = 1.0f;
         bodySettings.mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity();
         bodySettings.mGravityFactor = 0.0f;
-		bodySettings.mUseManifoldReduction = false; // Important pour les kinematic		
-		
+        bodySettings.mUseManifoldReduction = false; // Important pour les kinematic
+        bodySettings.mMotionQuality = JPH::EMotionQuality::LinearCast;
     }
 
     JPH::BodyInterface& bodyInterface = physicsSystem->GetBodyInterface();
@@ -117,7 +130,15 @@ void RigidbodyComponent::Awake() {
  * </summary>
  */
 void RigidbodyComponent::Update(float deltaTime) {
-    (void)deltaTime;
+    if (!isKinematic)
+        return;
+
+    auto* transform = GetEntity()->GetComponent<NNE::Component::TransformComponent>();
+    if (transform && (transform->position != lastPosition || transform->rotation != lastRotation)) {
+        MoveKinematic(transform->position, transform->rotation, deltaTime);
+        lastPosition = transform->position;
+        lastRotation = transform->rotation;
+    }
 }
 
 /**
@@ -148,16 +169,21 @@ void RigidbodyComponent::SetLinearVelocity(glm::vec3 velocity) {
  * Déplace un corps cinématique vers une nouvelle position.
  * </summary>
  */
-void RigidbodyComponent::MoveKinematic(glm::vec3 position, float deltaTime) {
+
+void RigidbodyComponent::MoveKinematic(glm::vec3 position, glm::vec3 rotation, float deltaTime) {
+
     if (!isKinematic)
         return;
 
     auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
     auto& bodyInterface = physicsSystem->GetBodyInterface();
     if (!bodyID.IsInvalid()) {
+        glm::vec3 radians = glm::radians(rotation);
+        glm::quat q = glm::quat(radians);
+        JPH::Quat orient(q.x, q.y, q.z, q.w);
         bodyInterface.MoveKinematic(bodyID,
                                     JPH::RVec3(position.x, position.y, position.z),
-                                    JPH::Quat::sIdentity(),
+                                    orient,
                                     deltaTime);
     }
 }

--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -10,9 +10,6 @@ namespace NNE::Systems {
 UISystem::UISystem(VulkanManager* manager) : _vkManager(manager) {}
 
 void UISystem::Start() {
-    if (_vkManager) {
-        _vkManager->initImGui();
-    }
     _app = Application::GetInstance();
 }
 

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -1421,17 +1421,18 @@ void NNE::Systems::VulkanManager::recreateSwapChain()
     createSwapChain();
     createImageViews();
     createRenderPass();   // Assurez-vous que le render pass est bien recréé !
+    createGraphicsPipeline(); // Le pipeline dépend du render pass
     createColorResources();
     createDepthResources();
     createFramebuffers();
 
-    // 🔥 Recréer les buffers uniformes et le pipeline si nécessaire
+    // 🔥 Recréer les buffers uniformes et les descripteurs
     createUniformBuffers();
     createDescriptorPool();
     createDescriptorSets();
     createCommandBuffers();
 
-	updateCameraAspectRatio();
+        updateCameraAspectRatio();
 }
 
 void NNE::Systems::VulkanManager::updateCameraAspectRatio()
@@ -2226,6 +2227,16 @@ void NNE::Systems::VulkanManager::cleanupSwapChain()
     if (descriptorPool != VK_NULL_HANDLE) {
         vkDestroyDescriptorPool(device, descriptorPool, nullptr);
         descriptorPool = VK_NULL_HANDLE;
+    }
+
+    // Détruire le pipeline et son layout avant de recréer le swapchain
+    if (graphicsPipeline != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device, graphicsPipeline, nullptr);
+        graphicsPipeline = VK_NULL_HANDLE;
+    }
+    if (pipelineLayout != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
+        pipelineLayout = VK_NULL_HANDLE;
     }
 
     if (renderPass != VK_NULL_HANDLE) {

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -857,13 +857,7 @@ void NNE::Systems::VulkanManager::initImGui()
     ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
-    io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
     ImGui::StyleColorsDark();
-    ImGuiStyle& style = ImGui::GetStyle();
-    if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
-        style.WindowRounding = 0.0f;
-        style.Colors[ImGuiCol_WindowBg].w = 1.0f;
-    }
 
     VkDescriptorPoolSize pool_sizes[] = {
         { VK_DESCRIPTOR_TYPE_SAMPLER, 1000 },

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -1415,6 +1415,12 @@ void NNE::Systems::VulkanManager::recreateSwapChain()
 
     vkDeviceWaitIdle(device); // Attendre l'inactivité du GPU avant la mise à jour
 
+    // Les ressources ImGui sont liées au render pass et au swapchain.
+    // Lors d'une recréation du swapchain, le render pass change et les
+    // pipelines ImGui deviennent incompatibles (mismatch de format/samples).
+    // On détruit donc proprement ImGui avant de recréer les ressources.
+    cleanupImGui();
+
     cleanupSwapChain(); // Nettoyer correctement les ressources liées au swapchain
 
     // 🔥 Recréer les ressources du swapchain
@@ -1432,7 +1438,10 @@ void NNE::Systems::VulkanManager::recreateSwapChain()
     createDescriptorSets();
     createCommandBuffers();
 
-        updateCameraAspectRatio();
+    // Recréer les ressources ImGui avec le nouveau render pass / swapchain
+    initImGui();
+
+    updateCameraAspectRatio();
 }
 
 void NNE::Systems::VulkanManager::updateCameraAspectRatio()

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -89,7 +89,7 @@ void NNE::Systems::VulkanManager::initVulkan()
     createDepthResources();         // 📏 Créer une image de profondeur
 
     createFramebuffers();           // 🖼 Associer toutes les ressources au framebuffer
-    //initImGui();
+    initImGui();
 }
 
 
@@ -904,7 +904,7 @@ void NNE::Systems::VulkanManager::initImGui()
             throw std::runtime_error("ImGui Vulkan backend error");
         }
     };
-	init_info.RenderPass = renderPass;
+    init_info.RenderPass = renderPass;
     ImGui_ImplVulkan_Init(&init_info);
 
     VkCommandBuffer cmd = beginSingleTimeCommands();


### PR DESCRIPTION
## Summary
- Rebuild graphics pipeline when swapchain is recreated
- Destroy pipeline and layout with swapchain cleanup to ensure render pass compatibility

