### PR TITLE
Reinitialize ImGui with new swapchain

### DIFF
--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -10,9 +10,6 @@ namespace NNE::Systems {
 UISystem::UISystem(VulkanManager* manager) : _vkManager(manager) {}
 
 void UISystem::Start() {
-    if (_vkManager) {
-        _vkManager->initImGui();
-    }
     _app = Application::GetInstance();
 }
 

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -89,7 +89,7 @@ void NNE::Systems::VulkanManager::initVulkan()
     createDepthResources();         // 📏 Créer une image de profondeur
 
     createFramebuffers();           // 🖼 Associer toutes les ressources au framebuffer
-    //initImGui();
+    initImGui();
 }
 
 
@@ -904,7 +904,7 @@ void NNE::Systems::VulkanManager::initImGui()
             throw std::runtime_error("ImGui Vulkan backend error");
         }
     };
-	init_info.RenderPass = renderPass;
+    init_info.RenderPass = renderPass;
     ImGui_ImplVulkan_Init(&init_info);
 
     VkCommandBuffer cmd = beginSingleTimeCommands();
@@ -1415,6 +1415,12 @@ void NNE::Systems::VulkanManager::recreateSwapChain()
 
     vkDeviceWaitIdle(device); // Attendre l'inactivité du GPU avant la mise à jour
 
+    // Les ressources ImGui sont liées au render pass et au swapchain.
+    // Lors d'une recréation du swapchain, le render pass change et les
+    // pipelines ImGui deviennent incompatibles (mismatch de format/samples).
+    // On détruit donc proprement ImGui avant de recréer les ressources.
+    cleanupImGui();
+
     cleanupSwapChain(); // Nettoyer correctement les ressources liées au swapchain
 
     // 🔥 Recréer les ressources du swapchain
@@ -1432,7 +1438,10 @@ void NNE::Systems::VulkanManager::recreateSwapChain()
     createDescriptorSets();
     createCommandBuffers();
 
-        updateCameraAspectRatio();
+    // Recréer les ressources ImGui avec le nouveau render pass / swapchain
+    initImGui();
+
+    updateCameraAspectRatio();
 }
 
 void NNE::Systems::VulkanManager::updateCameraAspectRatio()


### PR DESCRIPTION
## Summary
- Initialize ImGui after creating the swapchain and render pass so its pipeline matches active resources
- Drop redundant UI system initialization; Vulkan manager now owns ImGui setup
- Ensure ImGui backend uses current render pass and MSAA settings
