### PR TITLE
Reinitialize ImGui with new swapchain

### DIFF
--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -10,9 +10,6 @@ namespace NNE::Systems {
 UISystem::UISystem(VulkanManager* manager) : _vkManager(manager) {}
 
 void UISystem::Start() {
-    if (_vkManager) {
-        _vkManager->initImGui();
-    }
     _app = Application::GetInstance();
 }
 


### PR DESCRIPTION
## Summary
- Initialize ImGui after creating the swapchain and render pass so its pipeline matches active resources
- Drop redundant UI system initialization; Vulkan manager now owns ImGui setup
- Ensure ImGui backend uses current render pass and MSAA settings
- Disable ImGui multi-viewports to avoid render pass mismatches during profiler

