### PR TITLE
Add light component and clean up light buffers

### DIFF
--- a/examples/src/Main.cpp
+++ b/examples/src/Main.cpp
@@ -5,6 +5,7 @@
 #include "RigidbodyComponent.h"
 #include "MeshComponent.h"
 #include "CameraComponent.h"
+#include "LightComponent.h"
 #include "PhysicsSystem.h"
 
 #include "VulkanManager.h"
@@ -85,6 +86,10 @@ int main() {
     TC2->position = glm::vec3(0.0f, 1.0f, 0.0f);
     TC2->rotation = glm::vec3(0.0f, 0.0f, 0.0f);
     app.VKManager->activeCamera = CC;
+
+    NNE::AEntity* light = app.CreateEntity();
+    auto* LC = light->AddComponent<NNE::Component::Render::LightComponent>();
+    app.VKManager->activeLight = LC;
 
     app.Init();
     app.Update();

--- a/src/include/LightComponent.h
+++ b/src/include/LightComponent.h
@@ -1,0 +1,79 @@
+#pragma once
+#include "AComponent.h"
+#include <glm/glm.hpp>
+
+namespace NNE::Component::Render {
+    class LightComponent : public NNE::Component::AComponent {
+    private:
+        glm::vec3 direction;
+        glm::vec3 color;
+        float intensity;
+        float ambient;
+
+    public:
+        /**
+         * <summary>
+         * Crée un composant de lumière directionnelle.
+         * </summary>
+         */
+        LightComponent(const glm::vec3& dir = glm::vec3(-1.f, -1.f, -1.f),
+                       const glm::vec3& color = glm::vec3(1.f),
+                       float intensity = 1.f,
+                       float ambient = 0.25f);
+        /**
+         * <summary>
+         * Met à jour la direction selon la transformation de l'entité.
+         * </summary>
+         */
+        void Update(float deltaTime) override;
+
+        /**
+         * <summary>
+         * Définit la direction de la lumière.
+         * </summary>
+         */
+        void SetDirection(const glm::vec3& dir);
+        /**
+         * <summary>
+         * Retourne la direction actuelle de la lumière.
+         * </summary>
+         */
+        glm::vec3 GetDirection() const;
+        /**
+         * <summary>
+         * Modifie la couleur de la lumière.
+         * </summary>
+         */
+        void SetColor(const glm::vec3& col);
+        /**
+         * <summary>
+         * Retourne la couleur de la lumière.
+         * </summary>
+         */
+        glm::vec3 GetColor() const;
+        /**
+         * <summary>
+         * Définit l'intensité de la lumière.
+         * </summary>
+         */
+        void SetIntensity(float i);
+        /**
+         * <summary>
+         * Retourne l'intensité de la lumière.
+         * </summary>
+         */
+        float GetIntensity() const;
+        /**
+         * <summary>
+         * Définit la composante ambiante.
+         * </summary>
+         */
+        void SetAmbient(float a);
+        /**
+         * <summary>
+         * Retourne la composante ambiante.
+         * </summary>
+         */
+        float GetAmbient() const;
+    };
+}

--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -18,6 +18,7 @@
 #include "CameraComponent.h"
 #include "MeshComponent.h"
 #include "TransformComponent.h"
+#include "LightComponent.h"
 
 #define NOMINMAX //Necessary for ::Max()
 #define VK_USE_PLATFORM_WIN32_KHR
@@ -193,9 +194,10 @@ namespace NNE::Systems {
                 VkSampleCountFlagBits msaaSamples = VK_SAMPLE_COUNT_8_BIT;
                 bool supportsRenderToSingleSampled = false;
 
-	public :
+        public :
             NNE::Component::Render::CameraComponent* activeCamera = nullptr;
-		VkInstance instance = VK_NULL_HANDLE;
+            NNE::Component::Render::LightComponent* activeLight = nullptr;
+                VkInstance instance = VK_NULL_HANDLE;
         std::vector<Vertex> vertices;
         std::vector<uint32_t> indices;
 		GLFWwindow* window;

--- a/src/src/LightComponent.cpp
+++ b/src/src/LightComponent.cpp
@@ -1,0 +1,64 @@
+#include "LightComponent.h"
+#include "TransformComponent.h"
+
+/**
+ * <summary>
+ * Initialise une lumière directionnelle.
+ * </summary>
+ */
+NNE::Component::Render::LightComponent::LightComponent(const glm::vec3& dir, const glm::vec3& color, float intensity, float ambient)
+    : direction(glm::normalize(dir)), color(color), intensity(intensity), ambient(ambient) {}
+
+/**
+ * <summary>
+ * Met à jour la direction de la lumière selon la transformation de l'entité.
+ * </summary>
+ */
+void NNE::Component::Render::LightComponent::Update(float deltaTime)
+{
+    (void)deltaTime;
+    if (auto* transform = _entity->GetComponent<NNE::Component::TransformComponent>()) {
+        direction = -transform->GetForward();
+    }
+}
+
+void NNE::Component::Render::LightComponent::SetDirection(const glm::vec3& dir)
+{
+    direction = glm::normalize(dir);
+}
+
+glm::vec3 NNE::Component::Render::LightComponent::GetDirection() const
+{
+    return direction;
+}
+
+void NNE::Component::Render::LightComponent::SetColor(const glm::vec3& col)
+{
+    color = col;
+}
+
+glm::vec3 NNE::Component::Render::LightComponent::GetColor() const
+{
+    return color;
+}
+
+void NNE::Component::Render::LightComponent::SetIntensity(float i)
+{
+    intensity = i;
+}
+
+float NNE::Component::Render::LightComponent::GetIntensity() const
+{
+    return intensity;
+}
+
+void NNE::Component::Render::LightComponent::SetAmbient(float a)
+{
+    ambient = a;
+}
+
+float NNE::Component::Render::LightComponent::GetAmbient() const
+{
+    return ambient;
+}
+

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -1109,9 +1109,18 @@ void NNE::Systems::VulkanManager::updateUniformBuffer(uint32_t currentImage)
 
     GlobalUniformBufferObject globalUBO{};
     globalUBO.view = activeCamera->GetViewMatrix();
-    globalUBO.proj = activeCamera->GetProjectionMatrix();    
+    globalUBO.proj = activeCamera->GetProjectionMatrix();
 
     memcpy(uniformBuffersMapped[currentImage], &globalUBO, sizeof(globalUBO));
+
+    if (activeLight) {
+        LightUBO l{};
+        l.dir = activeLight->GetDirection();
+        l.intensity = activeLight->GetIntensity();
+        l.color = activeLight->GetColor();
+        l.ambient = activeLight->GetAmbient();
+        memcpy(lightBuffersMapped[currentImage], &l, sizeof(LightUBO));
+    }
         
 }
 
@@ -2170,6 +2179,15 @@ void NNE::Systems::VulkanManager::CleanUp()
             vkFreeMemory(device, objectUniformBuffersMemory[i], nullptr);
             objectUniformBuffersMemory[i] = VK_NULL_HANDLE;
         }
+
+        if (lightBuffers[i] != VK_NULL_HANDLE) {
+            vkDestroyBuffer(device, lightBuffers[i], nullptr);
+            lightBuffers[i] = VK_NULL_HANDLE;
+        }
+        if (lightBuffersMemory[i] != VK_NULL_HANDLE) {
+            vkFreeMemory(device, lightBuffersMemory[i], nullptr);
+            lightBuffersMemory[i] = VK_NULL_HANDLE;
+        }
     }
 
     
@@ -2321,6 +2339,18 @@ void NNE::Systems::VulkanManager::cleanupSwapChain()
         if (objectUniformBuffersMemory[i] != VK_NULL_HANDLE) {
             vkFreeMemory(device, objectUniformBuffersMemory[i], nullptr);
             objectUniformBuffersMemory[i] = VK_NULL_HANDLE;
+        }
+    }
+
+    // Idem pour lightBuffers
+    for (size_t i = 0; i < lightBuffers.size(); i++) {
+        if (lightBuffers[i] != VK_NULL_HANDLE) {
+            vkDestroyBuffer(device, lightBuffers[i], nullptr);
+            lightBuffers[i] = VK_NULL_HANDLE;
+        }
+        if (lightBuffersMemory[i] != VK_NULL_HANDLE) {
+            vkFreeMemory(device, lightBuffersMemory[i], nullptr);
+            lightBuffersMemory[i] = VK_NULL_HANDLE;
         }
     }
 


### PR DESCRIPTION
## Summary
- manage light data through new `LightComponent`
- track active light in Vulkan manager and update light UBO
- ensure light uniform buffers are destroyed during cleanup
- demonstrate light component usage in example

## Testing
- `./scripts/install_dependencies.sh` *(fails: 403  Forbidden [IP: 172.30.1.115 8080])*
- `./scripts/build.sh` *(fails: Could not find a package configuration file provided by "glfw3")*


------
https://chatgpt.com/codex/tasks/task_e_68bcb57e6074832abdebd005dff8b85a