### PR TITLE
Add shadow mapping pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -442,3 +442,6 @@ FodyWeavers.xsd
 build/
 *.sln
 *.vcxproj*
+
+# Shader binaries
+*.spv

--- a/src/include/LightComponent.h
+++ b/src/include/LightComponent.h
@@ -17,7 +17,7 @@ namespace NNE::Component::Render {
          * Crée un composant de lumière directionnelle.
          * </summary>
          */
-        LightComponent(const glm::vec3& dir = glm::vec3(-1.f, -1.f, -1.f),
+        LightComponent(const glm::vec3& dir = glm::vec3(-0.2f, -1.5f, -0.3f),
                        const glm::vec3& color = glm::vec3(1.f),
                        float intensity = 1.f,
                        float ambient = 0.25f);

--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -111,6 +111,7 @@ namespace NNE::Systems {
     struct GlobalUniformBufferObject {
             alignas(16)glm::mat4 view;
             alignas(16)glm::mat4 proj;
+            alignas(16)glm::mat4 lightSpace;
     };
 
     struct alignas(16) LightUBO {
@@ -121,9 +122,10 @@ namespace NNE::Systems {
     class VulkanManager
 	{
 	protected:
-		size_t dynamicAlignment;
-		const size_t MAX_OBJECTS = 100;
-		const int MAX_FRAMES_IN_FLIGHT = 2;
+                size_t dynamicAlignment;
+                const size_t MAX_OBJECTS = 100;
+                const int MAX_FRAMES_IN_FLIGHT = 2;
+                const uint32_t SHADOW_MAP_DIM = 2048;
 		VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
 		//VkDevice device = VK_NULL_HANDLE;
 		VkQueue graphicsQueue = VK_NULL_HANDLE;
@@ -193,6 +195,18 @@ namespace NNE::Systems {
                 VkImageView depthImageView;
                 VkSampleCountFlagBits msaaSamples = VK_SAMPLE_COUNT_8_BIT;
                 bool supportsRenderToSingleSampled = false;
+
+                // Shadow mapping resources
+                VkRenderPass shadowRenderPass;
+                VkFramebuffer shadowFramebuffer;
+                VkImage shadowImage;
+                VkDeviceMemory shadowImageMemory;
+                VkImageView shadowImageView;
+                VkSampler shadowSampler;
+                VkPipeline shadowPipeline;
+                VkPipelineLayout shadowPipelineLayout;
+                VkDescriptorSetLayout shadowDescriptorSetLayout;
+                std::array<VkDescriptorSet, MAX_FRAMES_IN_FLIGHT> shadowDescriptorSets;
 
         public :
             NNE::Component::Render::CameraComponent* activeCamera = nullptr;
@@ -287,12 +301,14 @@ namespace NNE::Systems {
                 * </summary>
                 */
             void createRenderPass();
+            void createShadowRenderPass();
             /**
                 * <summary>
                 * Génère le pipeline graphique.
                 * </summary>
                 */
             void createGraphicsPipeline();
+            void createShadowPipeline();
             /**
                 * <summary>
                 * Crée un buffer Vulkan générique.
@@ -359,6 +375,7 @@ namespace NNE::Systems {
                 * </summary>
                 */
             void createDescriptorSetLayout();
+            void createShadowDescriptorSetLayout();
             /**
                 * <summary>
                 * Crée le pool de descripteurs.
@@ -371,6 +388,7 @@ namespace NNE::Systems {
                 * </summary>
                 */
             void createDescriptorSets();
+            void createShadowDescriptorSets();
             /**
                 * <summary>
                 * Dessine une frame complète.
@@ -420,6 +438,7 @@ namespace NNE::Systems {
                 * </summary>
                 */
             void createDepthResources();
+            void createShadowResources();
             /**
                 * <summary>
                 * Génère les mipmaps d'une image.

--- a/src/shaders/shader.frag
+++ b/src/shaders/shader.frag
@@ -3,6 +3,7 @@
 layout(location = 0) in vec3 fragColor;
 layout(location = 1) in vec2 fragTexCoord;
 layout(location = 2) in vec3 fragNormal;
+layout(location = 3) in vec4 fragPosLight;
 
 layout(location = 0) out vec4 outColor;
 layout(set = 0, binding = 1) uniform sampler2D texSampler;
@@ -11,6 +12,8 @@ layout(set = 0, binding = 2) uniform LightUBO {
     vec3 dir;       float intensity;  // dir = direction *depuis* la lumière (ex: (−1,−1,−1))
     vec3 color;     float ambient;    // ambient = facteur [0..1]
 } light;
+
+layout(set = 0, binding = 3) uniform sampler2D shadowMap;
 
 layout(push_constant) uniform PushConstants {
     mat4 model;
@@ -29,5 +32,15 @@ void main() {
 
     vec3 diffuse = base * light.color * (light.intensity * NdotL);
     vec3 ambient = base * light.ambient;
-    outColor = vec4(ambient + diffuse, 1.0);
+
+    vec3 projCoords = fragPosLight.xyz / fragPosLight.w;
+    projCoords = projCoords * 0.5 + 0.5;
+    float shadow = 0.0;
+    if (projCoords.z <= 1.0) {
+        float closest = texture(shadowMap, projCoords.xy).r;
+        float bias = max(0.05 * (1.0 - dot(N, L)), 0.005);
+        shadow = projCoords.z - bias > closest ? 1.0 : 0.0;
+    }
+
+    outColor = vec4(ambient + (1.0 - shadow) * diffuse, 1.0);
 }

--- a/src/shaders/shader.vert
+++ b/src/shaders/shader.vert
@@ -3,6 +3,7 @@
 layout(set = 0, binding = 0) uniform GlobalUBO {
     mat4 view;
     mat4 proj;
+    mat4 lightSpace;
 } globalUBO;
 
 //layout(set = 0, binding = 1) uniform ObjectUBO {
@@ -23,6 +24,7 @@ layout(location = 3) in vec3 inNormal;
 layout(location = 0) out vec3 fragColor;
 layout(location = 1) out vec2 fragTexCoord;
 layout(location = 2) out vec3 fragNormal;
+layout(location = 3) out vec4 fragPosLight;
 
 void main() { 
     mat4 M = pushConstants.model;
@@ -35,4 +37,5 @@ void main() {
 
     fragColor = inColor;
     fragTexCoord = inTexCoord;
+    fragPosLight = globalUBO.lightSpace * M * vec4(inPosition,1.0);
 }

--- a/src/shaders/shadow.frag
+++ b/src/shaders/shadow.frag
@@ -1,0 +1,2 @@
+#version 450
+void main() {}

--- a/src/shaders/shadow.vert
+++ b/src/shaders/shadow.vert
@@ -1,0 +1,18 @@
+#version 450
+layout(set = 0, binding = 0) uniform GlobalUBO {
+    mat4 view;
+    mat4 proj;
+    mat4 lightSpace;
+} globalUBO;
+
+layout(push_constant) uniform PushConstants {
+    mat4 model;
+    vec2 tiling;
+    vec2 offset;
+} pushConstants;
+
+layout(location = 0) in vec3 inPosition;
+
+void main() {
+    gl_Position = globalUBO.lightSpace * pushConstants.model * vec4(inPosition, 1.0);
+}


### PR DESCRIPTION
## Summary
- refine directional light-space matrix to position sun above the scene
- isolate shadow mapping into its own descriptor and pipeline layout with dedicated descriptor sets
- add synchronization dependency and bind shadow descriptors each frame to enable inter-object shadows

## Testing
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*
- `apt-get install -y libglfw3-dev` *(fails: Unable to locate package libglfw3-dev)*
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glfw3")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8ffeacc0832abaf11be343107af5