### PR TITLE
Add projCoords debug shader and tweak light frustum

### DIFF
--- a/src/shaders/shader.frag
+++ b/src/shaders/shader.frag
@@ -19,6 +19,7 @@ layout(push_constant) uniform PushConstants {
     mat4 model;
     vec2 tiling;
     vec2 offset;
+    int debug;
 } pushConstants;
 
 void main() {
@@ -35,6 +36,15 @@ void main() {
 
     vec3 projCoords = fragPosLight.xyz / fragPosLight.w;
     projCoords = projCoords * 0.5 + 0.5;
+    if (pushConstants.debug != 0) {
+        if (projCoords.x < 0.0 || projCoords.x > 1.0 ||
+            projCoords.y < 0.0 || projCoords.y > 1.0) {
+            outColor = vec4(1.0, 0.0, 0.0, 1.0);
+        } else {
+            outColor = vec4(projCoords, 1.0);
+        }
+        return;
+    }
     float shadow = 0.0;
     if (projCoords.z <= 1.0) {
         float closest = texture(shadowMap, projCoords.xy).r;

--- a/src/shaders/shader.vert
+++ b/src/shaders/shader.vert
@@ -14,6 +14,7 @@ layout(push_constant) uniform PushConstants {
     mat4 model;
     vec2 tiling;
     vec2 offset;
+    int debug;
 } pushConstants;
 
 layout(location = 0) in vec3 inPosition;

--- a/src/shaders/shadow.vert
+++ b/src/shaders/shadow.vert
@@ -9,6 +9,7 @@ layout(push_constant) uniform PushConstants {
     mat4 model;
     vec2 tiling;
     vec2 offset;
+    int debug;
 } pushConstants;
 
 layout(location = 0) in vec3 inPosition;

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -30,6 +30,7 @@ struct PushConstantObject {
     glm::mat4 model;
     alignas(16)glm::vec2 tiling;
     alignas(16)glm::vec2 offset;
+    alignas(4)int debug;
 };
 
 NNE::Systems::VulkanManager::VulkanManager()
@@ -1279,6 +1280,7 @@ void NNE::Systems::VulkanManager::recordCommandBuffer(VkCommandBuffer commandBuf
         pc.model = transform ? transform->getModelMatrix() : glm::mat4(1.0f);
         pc.tiling = mesh->GetMaterial().tiling;
         pc.offset = mesh->GetMaterial().offset;
+        pc.debug = 0; // set to 1 to visualize projCoords
 
         vkCmdPushConstants(commandBuffer, shadowPipelineLayout,
             VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -1338,6 +1340,7 @@ void NNE::Systems::VulkanManager::recordCommandBuffer(VkCommandBuffer commandBuf
         pc.model = transform ? transform->getModelMatrix() : glm::mat4(1.0f);
         pc.tiling = mesh->GetMaterial().tiling;
         pc.offset = mesh->GetMaterial().offset;
+        pc.debug = 0; // set to 1 to visualize projCoords
 
         vkCmdPushConstants(commandBuffer, pipelineLayout,
             VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -1390,7 +1393,7 @@ void NNE::Systems::VulkanManager::updateUniformBuffer(uint32_t currentImage)
         }
         float range = activeCamera->GetFarPlane();
         glm::mat4 lightView = glm::lookAt(lightPos, lightPos + activeLight->GetDirection(), glm::vec3(0.f, 1.f, 0.f));
-        glm::mat4 lightProj = glm::ortho(-range, range, -range, range, 0.1f, range * 2.f);
+        glm::mat4 lightProj = glm::ortho(-range, range, -range, range, -range, range);
         globalUBO.lightSpace = lightProj * lightView;
     }
 


### PR DESCRIPTION
## Summary
- add push-constant flag and color visualization of projCoords for shadow debugging
- extend push-constant structs and CPU usage to carry debug flag
- tighten light-space frustum to [-range, range]

## Testing
- `./scripts/build.sh` *(fails: Could not find a package configuration file provided by "glfw3")*


------
https://chatgpt.com/codex/tasks/task_e_68bedd2e441c832a96e3ead96957e134