### PR TITLE
Ensure shadow map coordinates stay in bounds

### DIFF
--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -530,6 +530,18 @@ namespace NNE::Systems {
             void copyBufferToImage(VkBuffer buffer, VkImage image, uint32_t width, uint32_t height);
             /**
                 * <summary>
+                * Copie les données d'une image vers un buffer.
+                * </summary>
+                */
+            void copyImageToBuffer(VkImage image, VkBuffer buffer, uint32_t width, uint32_t height);
+            /**
+                * <summary>
+                * Affiche des statistiques sur la shadow map pour vérifier son contenu.
+                * </summary>
+                */
+            void debugShadowMap();
+            /**
+                * <summary>
                 * Crée un module de shader à partir de code binaire.
                 * </summary>
                 */

--- a/src/shaders/shader.frag
+++ b/src/shaders/shader.frag
@@ -36,7 +36,9 @@ void main() {
     vec3 projCoords = fragPosLight.xyz / fragPosLight.w;
     projCoords = projCoords * 0.5 + 0.5;
     float shadow = 0.0;
-    if (projCoords.z <= 1.0) {
+    if (projCoords.z >= 0.0 && projCoords.z <= 1.0 &&
+        projCoords.x >= 0.0 && projCoords.x <= 1.0 &&
+        projCoords.y >= 0.0 && projCoords.y <= 1.0) {
         float closest = texture(shadowMap, projCoords.xy).r;
         float bias = max(0.05 * (1.0 - dot(N, L)), 0.005);
         shadow = projCoords.z - bias > closest ? 1.0 : 0.0;


### PR DESCRIPTION
## Summary
- guard shadow map sampling against out-of-range coordinates
- add debug routine to inspect shadow map and report depth range each frame
