### PR TITLE
Add shadow map debug request via input

### DIFF
--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -208,6 +208,8 @@ namespace NNE::Systems {
                 VkDescriptorSetLayout shadowDescriptorSetLayout;
                 std::array<VkDescriptorSet, MAX_FRAMES_IN_FLIGHT> shadowDescriptorSets;
 
+        private:
+                bool shadowDebugRequested;
 
         public :
             NNE::Component::Render::CameraComponent* activeCamera = nullptr;
@@ -546,6 +548,7 @@ namespace NNE::Systems {
                 * </summary>
                 */
             void debugShadowMap();
+            void requestShadowDebug();
             /**
                 * <summary>
                 * Crée un module de shader à partir de code binaire.

--- a/src/src/InputSystem.cpp
+++ b/src/src/InputSystem.cpp
@@ -1,4 +1,6 @@
 #include "InputSystem.h"
+#include "Application.h"
+#include "VulkanManager.h"
 
 namespace NNE::Systems {
 
@@ -11,6 +13,10 @@ void InputSystem::Update(float deltaTime)
 {
     (void)deltaTime;
     InputManager::Update();
+    if (InputManager::IsKeyJustPressed(GLFW_KEY_F3))
+    {
+        Application::GetInstance()->VKManager->requestShadowDebug();
+    }
     for (auto* input : _inputs)
     {
         for (auto& pair : input->buttons)

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -63,6 +63,8 @@ NNE::Systems::VulkanManager::VulkanManager()
     shadowDescriptorSetLayout = VK_NULL_HANDLE;
     shadowDescriptorSets.fill(VK_NULL_HANDLE);
 
+    shadowDebugRequested = false;
+
     vertexBuffer = VK_NULL_HANDLE;
     vertexBufferMemory = VK_NULL_HANDLE;
     indexBuffer = VK_NULL_HANDLE;
@@ -1864,7 +1866,10 @@ void NNE::Systems::VulkanManager::drawFrame(const std::vector<std::pair<NNE::Com
             throw std::runtime_error("failed to submit draw command buffer!");
         }
 
-        debugShadowMap();
+        if (shadowDebugRequested) {
+            debugShadowMap();
+            shadowDebugRequested = false;
+        }
 
         VkPresentInfoKHR presentInfo{};
         presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
@@ -2584,6 +2589,11 @@ void NNE::Systems::VulkanManager::debugShadowMap()
 
     vkDestroyBuffer(device, stagingBuffer, nullptr);
     vkFreeMemory(device, stagingBufferMemory, nullptr);
+}
+
+void NNE::Systems::VulkanManager::requestShadowDebug()
+{
+    shadowDebugRequested = true;
 }
 
 VkShaderModule NNE::Systems::VulkanManager::createShaderModule(const std::vector<char>& code)


### PR DESCRIPTION
## Summary
- allow requesting a one-shot shadow map dump for debugging
- expose `requestShadowDebug` in VulkanManager and hook it to F3 key input

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glfw3")*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bef8d806e4832a93171a01376f0735