### PR TITLE
Fix shadow map layout and projection

### DIFF
--- a/src/shaders/compile.sh
+++ b/src/shaders/compile.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+glslc "$DIR/shader.vert" -o "$DIR/vert.spv"
+glslc "$DIR/shader.frag" -o "$DIR/frag.spv"
+glslc "$DIR/shadow.vert" -o "$DIR/shadow_vert.spv"
+glslc "$DIR/shadow.frag" -o "$DIR/shadow_frag.spv"

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -1318,9 +1318,32 @@ void NNE::Systems::VulkanManager::recordCommandBuffer(VkCommandBuffer commandBuf
         
     }
     std::cout << "[Shadow] casters count = " << objects.size() << std::endl;
-    
+
 
     vkCmdEndRenderPass(commandBuffer);
+
+    // Transition shadow map back to a readable layout for the main pass
+    VkImageMemoryBarrier shadowEndBarrier{};
+    shadowEndBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    shadowEndBarrier.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    shadowEndBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    shadowEndBarrier.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    shadowEndBarrier.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+    shadowEndBarrier.image = shadowImage;
+    shadowEndBarrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    shadowEndBarrier.subresourceRange.baseMipLevel = 0;
+    shadowEndBarrier.subresourceRange.levelCount = 1;
+    shadowEndBarrier.subresourceRange.baseArrayLayer = 0;
+    shadowEndBarrier.subresourceRange.layerCount = 1;
+
+    vkCmdPipelineBarrier(
+        commandBuffer,
+        VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+        VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+        0,
+        0, nullptr,
+        0, nullptr,
+        1, &shadowEndBarrier);
 
     VkRenderPassBeginInfo renderPassInfo{};
     renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
@@ -1471,6 +1494,8 @@ void NNE::Systems::VulkanManager::updateUniformBuffer(uint32_t currentImage)
             -radius, +radius,
             nearPlane, farPlane
         );
+        // Vulkan has inverted Y in clip space compared to OpenGL
+        lightProj[1][1] *= -1;
 
         // 5) UBO
         globalUBO.lightSpace = lightProj * lightView;


### PR DESCRIPTION
## Summary
- Transition shadow map image to `VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL` before sampling in the main pass
- Flip Y axis of light projection to match Vulkan clip space
- Add helper script to compile GLSL shaders to SPIR-V

