### PR TITLE
Add shadow map debug viewer and PNG export

### DIFF
--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -202,11 +202,13 @@ namespace NNE::Systems {
         VkDeviceMemory shadowImageMemory;
         VkImageView shadowImageView;
         VkSampler shadowSampler;
+        VkImageLayout shadowImageLayout;
         VkPipeline shadowPipeline;
 
         VkPipelineLayout shadowPipelineLayout;
         VkDescriptorSetLayout shadowDescriptorSetLayout;
         std::array<VkDescriptorSet, MAX_FRAMES_IN_FLIGHT> shadowDescriptorSets;
+        VkDescriptorSet shadowDebugDescriptor;
 
     private:
         bool shadowDebugRequested;
@@ -549,6 +551,7 @@ namespace NNE::Systems {
             */
         void debugShadowMap();
         void requestShadowDebug();
+        VkDescriptorSet getShadowMapDebugDescriptor();
         /**
             * <summary>
             * Crée un module de shader à partir de code binaire.

--- a/src/shaders/shader.frag
+++ b/src/shaders/shader.frag
@@ -25,7 +25,8 @@ layout(set = 0, binding = 3) uniform sampler2D shadowMap;
 
 float shadowFactor(vec3 N, vec3 L, vec4 lightClip) {
     vec3 proj = lightClip.xyz / lightClip.w;
-    proj = proj * 0.5 + 0.5;            // [-1,1] -> [0,1]
+    // En Vulkan la profondeur est déjà dans [0,1]
+    proj.xy = proj.xy * 0.5 + 0.5;      // [-1,1] -> [0,1] seulement pour x/y
 
     // Hors shadowmap = éclairé (ton sampler est CLAMP_TO_BORDER + WHITE, ça colle aussi)
     if (proj.x < 0.0 || proj.x > 1.0 || proj.y < 0.0 || proj.y > 1.0 || proj.z > 1.0)

--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -78,6 +78,16 @@ void UISystem::Update(float deltaTime) {
                     ImGui::EndTabItem();
                 }
 
+                if (ImGui::BeginTabItem("Shadow Map")) {
+                    VkDescriptorSet desc = _vkManager->getShadowMapDebugDescriptor();
+                    if (desc != VK_NULL_HANDLE) {
+                        ImGui::Image((ImTextureID)desc, ImVec2(256, 256), ImVec2(0, 1), ImVec2(1, 0));
+                    } else {
+                        ImGui::TextUnformatted("Shadow map unavailable");
+                    }
+                    ImGui::EndTabItem();
+                }
+
                 if (ImGui::BeginTabItem("Entities")) {
                     static std::unordered_map<NNE::AEntity*, std::array<char, 128>> nameBuffers;
                     for (NNE::AEntity* e : _app->_entities) {


### PR DESCRIPTION
## Summary
- Dump shadow map to `shadowmap.png` using stb_image_write for easier viewing
- Expose shadow map as ImGui texture and show it in new Debug tab
- Clean up ImGui resources for shadow debug descriptor
- Stabilize shadow frustum so camera pitch no longer loses shadows
- Transition shadow map to shader-readable layout after the shadow pass so the main render can sample it
- Track shadow map image layout to avoid invalid Vulkan layout transitions
- Rely on render pass final layout to handle shadow map transition, removing redundant barrier that triggered validation errors

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glfw3")*
- `sudo apt-get update` *(fails: 403  Forbidden [IP: 172.30.2.179 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68c12a53f7e4832a92e569ec444924bd