### PR TITLE
Refacto SOLID

### DIFF
--- a/examples/src/Main.cpp
+++ b/examples/src/Main.cpp
@@ -15,9 +15,9 @@
 
 int main() {
     NNE::Systems::Application app;
-    app.physicsSystem->SetLayerCollision(NNE::Systems::Layers::RAYCAST, NNE::Systems::Layers::PLAYER, false);
-    
-    app.physicsSystem->SetLayerCollision(NNE::Systems::Layers::RAYCAST, NNE::Systems::Layers::DEFAULT, true);
+    NNE::Systems::PhysicsSystem::GetInstance()->SetLayerCollision(NNE::Systems::Layers::RAYCAST, NNE::Systems::Layers::PLAYER, false);
+
+    NNE::Systems::PhysicsSystem::GetInstance()->SetLayerCollision(NNE::Systems::Layers::RAYCAST, NNE::Systems::Layers::DEFAULT, true);
 
 
 	NNE::AEntity* Skybox = app.CreateEntity();

--- a/examples/src/PlayerController.cpp
+++ b/examples/src/PlayerController.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <Application.h>
 #include <UISystem.h>
+#include <SystemManager.h>
 
 PlayerController::PlayerController()
 {
@@ -25,7 +26,8 @@ void PlayerController::Awake()
 
 void PlayerController::Update(float deltaTime)
 {
-	if (NNE::Systems::Application::GetInstance()->uiSystem->showPerf) return;
+        auto* ui = NNE::Systems::SystemManager::GetInstance()->GetSystem<NNE::Systems::UISystem>();
+        if (ui && ui->showPerf) return;
 
     direction = glm::vec3(0.0f);
 

--- a/src/include/AComponent.h
+++ b/src/include/AComponent.h
@@ -48,7 +48,7 @@ namespace NNE::Component {
                  * Retourne l'identifiant du composant.
                  * </summary>
                  */
-                int GetID();
+                int GetID() const;
                 /**
                  * <summary>
                  * Obtient l'entité propriétaire.

--- a/src/include/Application.h
+++ b/src/include/Application.h
@@ -1,38 +1,21 @@
 #pragma once
 #include <iostream>
 #include <vector>
-#include <map>
 
 #include <Jolt/Jolt.h>
-#include <Jolt/Physics/Body/BodyID.h>
-
-#include <unordered_map>
 
 namespace NNE { class AEntity; }
 
-namespace NNE::Component::Physics { class ColliderComponent; }
-
 namespace NNE::Systems {
 class VulkanManager;
-class PhysicsSystem;
-class RenderSystem;
-class UISystem;
-class InputSystem;
-class ScriptSystem;
-class LightSystem;
-class ISystem;
 
 class Application
 {
         protected:
 
-                std::map<int, int> _link;
                 static Application* Instance;
                 /*GLFWwindow* window;*/
                 float delta;
-                
-
-                static int _genericID;
 
 		
 
@@ -70,14 +53,7 @@ class Application
                  */
                 ~Application();
                 NNE::Systems::VulkanManager* VKManager;
-                NNE::Systems::PhysicsSystem* physicsSystem;
-                NNE::Systems::UISystem* uiSystem;
-                NNE::Systems::RenderSystem* renderSystem;
-                NNE::Systems::InputSystem* inputSystem;
-                NNE::Systems::ScriptSystem* scriptSystem;
-                NNE::Systems::LightSystem* lightSystem;
                 std::vector<NNE::AEntity*> _entities;
-                std::vector<NNE::Systems::ISystem*>& _systems;
 
                 /**
                  * <summary>
@@ -106,47 +82,11 @@ class Application
 
                 /**
                  * <summary>
-                 * Génère un identifiant unique pour les entités.
-                 * </summary>
-                 */
-                int GenerateID();
-
-                /**
-                 * <summary>
                  * Crée une nouvelle entité gérée par l'application.
                  * </summary>
                  */
                 NNE::AEntity* CreateEntity();
 
-                std::unordered_map<JPH::BodyID, NNE::Component::Physics::ColliderComponent*> colliderMap;
-
-                /**
-                 * <summary>
-                 * Associe un collider à son identifiant physique.
-                 * </summary>
-                 */
-                void RegisterCollider(JPH::BodyID id, NNE::Component::Physics::ColliderComponent* collider) {
-                        colliderMap[id] = collider;
-                }
-
-                /**
-                 * <summary>
-                 * Récupère le collider lié à un identifiant physique.
-                 * </summary>
-                 */
-                NNE::Component::Physics::ColliderComponent* GetCollider(JPH::BodyID id) {
-                        auto it = colliderMap.find(id);
-                        return it != colliderMap.end() ? it->second : nullptr;
-                }
-
-                /**
-                 * <summary>
-                 * Retire un collider du suivi par identifiant.
-                 * </summary>
-                 */
-                void UnregisterCollider(JPH::BodyID id) {
-                        colliderMap.erase(id);
-                }
 };
 }
 

--- a/src/include/PhysicsSystem.h
+++ b/src/include/PhysicsSystem.h
@@ -4,10 +4,12 @@
 #include <Jolt/Core/JobSystemThreadPool.h>
 #include <Jolt/Physics/PhysicsSystem.h>
 #include <Jolt/Physics/Collision/ObjectLayer.h>
+#include <Jolt/Physics/Body/BodyID.h>
 #include <Jolt/RegisterTypes.h>
 #include "ISystem.h"
 #include <vector>
 #include <array>
+#include <unordered_map>
 #include <glm/glm.hpp>
 #include "AEntity.h"
 
@@ -24,11 +26,13 @@ namespace NNE::Systems {
 
     class PhysicsSystem : public ISystem {
     private:
+        static PhysicsSystem* instance;
         JPH::PhysicsSystem physicsSystem;
         JPH::TempAllocatorImpl* tempAllocator;
         JPH::JobSystemThreadPool* jobSystem;
         std::vector<NNE::Component::Physics::RigidbodyComponent*> rigidbodies;
         std::vector<NNE::Component::Physics::ColliderComponent*> colliders;
+        std::unordered_map<JPH::BodyID, NNE::Component::Physics::ColliderComponent*> colliderMap;
         std::array<uint32_t, 32> layerMasks;
         bool initialized;
 
@@ -89,6 +93,12 @@ namespace NNE::Systems {
          * </summary>
          */
         JPH::PhysicsSystem* GetPhysicsSystem();
+        /**
+         * <summary>
+         * Retourne l'instance unique du système physique.
+         * </summary>
+         */
+        static PhysicsSystem* GetInstance();
 
         /**
          * <summary>
@@ -103,6 +113,27 @@ namespace NNE::Systems {
          * </summary>
          */
         bool LayersShouldCollide(JPH::ObjectLayer layer1, JPH::ObjectLayer layer2) const;
+
+        /**
+         * <summary>
+         * Associe un collider à son identifiant physique.
+         * </summary>
+         */
+        void RegisterCollider(JPH::BodyID id, NNE::Component::Physics::ColliderComponent* collider);
+
+        /**
+         * <summary>
+         * Récupère le collider lié à un identifiant physique.
+         * </summary>
+         */
+        NNE::Component::Physics::ColliderComponent* GetCollider(JPH::BodyID id);
+
+        /**
+         * <summary>
+         * Retire un collider du suivi par identifiant.
+         * </summary>
+         */
+        void UnregisterCollider(JPH::BodyID id);
 
         struct RaycastHit {
             JPH::BodyID bodyID;

--- a/src/include/RenderSystem.h
+++ b/src/include/RenderSystem.h
@@ -11,7 +11,7 @@ class VulkanManager;
 
 class RenderSystem : public ISystem {
 private:
-    VulkanManager* _vkManager;
+    VulkanManager* _renderer;
     std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>> _renderObjects;
 
 public:

--- a/src/include/SystemManager.h
+++ b/src/include/SystemManager.h
@@ -39,5 +39,49 @@ public:
      * </summary>
      */
     void RegisterComponent(NNE::Component::AComponent* component);
+
+    /**
+     * <summary>
+     * Réveille tous les systèmes enregistrés.
+     * </summary>
+     */
+    void AwakeAll();
+    /**
+     * <summary>
+     * Démarre tous les systèmes enregistrés.
+     * </summary>
+     */
+    void StartAll();
+    /**
+     * <summary>
+     * Met à jour tous les systèmes enregistrés.
+     * </summary>
+     */
+    void UpdateAll(float deltaTime);
+    /**
+     * <summary>
+     * Applique les mises à jour tardives de tous les systèmes.
+     * </summary>
+     */
+    void LateUpdateAll(float deltaTime);
+    /**
+     * <summary>
+     * Supprime et nettoie tous les systèmes.
+     * </summary>
+     */
+    void Clear();
+
+    ~SystemManager();
+
+    template <typename T>
+    T* GetSystem()
+    {
+        for (ISystem* system : _systems)
+        {
+            if (auto casted = dynamic_cast<T*>(system))
+                return casted;
+        }
+        return nullptr;
+    }
 };
 }

--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -395,6 +395,18 @@ namespace NNE::Systems {
         void createShadowDescriptorSets();
         /**
             * <summary>
+            * Initialise les ressources de rendu.
+            * </summary>
+            */
+        void initializeRenderer(const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& objects);
+        /**
+            * <summary>
+            * Rend une frame.
+            * </summary>
+            */
+        void renderFrame(const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& objects);
+        /**
+            * <summary>
             * Dessine une frame complète.
             * </summary>
             */

--- a/src/src/AComponent.cpp
+++ b/src/src/AComponent.cpp
@@ -1,15 +1,16 @@
 #include "AComponent.h"
-#include "Application.h"
+#include <atomic>
 
 /**
  * <summary>
  * Assigne un identifiant unique au composant.
  * </summary>
  */
-NNE::Component::AComponent::AComponent()
-{
-        _id = NNE::Systems::Application::GetInstance()->GenerateID();
+namespace {
+std::atomic<int> g_nextComponentId{0};
 }
+
+NNE::Component::AComponent::AComponent() : _id(g_nextComponentId++) {}
 
 /**
  * <summary>
@@ -52,10 +53,7 @@ void NNE::Component::AComponent::LateUpdate(float deltaTime)
  * Renvoie l'identifiant du composant.
  * </summary>
  */
-int NNE::Component::AComponent::GetID()
-{
-        return _id;
-}
+int NNE::Component::AComponent::GetID() const { return _id; }
 
 /**
  * <summary>

--- a/src/src/AEntity.cpp
+++ b/src/src/AEntity.cpp
@@ -1,6 +1,6 @@
 #include "AEntity.h"
-#include "Application.h"
 #include "MonoComponent.h"
+#include <atomic>
 
 
 /**
@@ -8,11 +8,13 @@
  * Initialise l'entité avec un identifiant et un transform.
  * </summary>
  */
-NNE::AEntity::AEntity()
-{
-        _ID = NNE::Systems::Application::GetInstance()->GenerateID();
+namespace {
+std::atomic<int> g_nextEntityId{0};
+}
+
+NNE::AEntity::AEntity() : _ID(g_nextEntityId++) {
         transform = this->AddComponent<NNE::Component::TransformComponent>();
-		_Name = "Entity_" + std::to_string(_ID);
+        _Name = "Entity_" + std::to_string(_ID);
 }
 
 /**

--- a/src/src/BoxColliderComponent.cpp
+++ b/src/src/BoxColliderComponent.cpp
@@ -5,7 +5,6 @@
 #include <Jolt/Physics/Body/BodyInterface.h>
 
 #include "PhysicsSystem.h"
-#include "Application.h"
 #include "TransformComponent.h"
 #include "RigidbodyComponent.h"
 #include "AEntity.h"
@@ -48,9 +47,9 @@ void NNE::Component::Physics::BoxColliderComponent::CreateShape()
 
                 JPH::BodyCreationSettings bodySettings(shape, position, JPH::Quat::sIdentity(), JPH::EMotionType::Static, GetLayer());
                 bodySettings.mIsSensor = IsTrigger();
-                auto& bodyInterface = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem()->GetBodyInterface();
+                auto& bodyInterface = NNE::Systems::PhysicsSystem::GetInstance()->GetPhysicsSystem()->GetBodyInterface();
                 bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
 
-                NNE::Systems::Application::GetInstance()->RegisterCollider(bodyID, this);
+                NNE::Systems::PhysicsSystem::GetInstance()->RegisterCollider(bodyID, this);
         }
 }

--- a/src/src/ColliderComponent.cpp
+++ b/src/src/ColliderComponent.cpp
@@ -2,18 +2,17 @@
 #include "MonoComponent.h"
 #include "AEntity.h"
 #include "PhysicsSystem.h"
-#include "Application.h"
 #include <vector>
 #include <Jolt/Physics/Body/BodyInterface.h>
 
 NNE::Component::Physics::ColliderComponent::~ColliderComponent() {
-        auto app = NNE::Systems::Application::GetInstance();
+        auto* system = NNE::Systems::PhysicsSystem::GetInstance();
         if (!bodyID.IsInvalid()) {
-                app->physicsSystem->GetPhysicsSystem()->GetBodyInterface().RemoveBody(bodyID);
-                app->UnregisterCollider(bodyID);
+                system->GetPhysicsSystem()->GetBodyInterface().RemoveBody(bodyID);
+                system->UnregisterCollider(bodyID);
                 bodyID = JPH::BodyID();
         }
-        app->physicsSystem->UnregisterComponent(this);
+        system->UnregisterComponent(this);
 }
 
 

--- a/src/src/ColliderComponent.cpp
+++ b/src/src/ColliderComponent.cpp
@@ -6,13 +6,14 @@
 #include <Jolt/Physics/Body/BodyInterface.h>
 
 NNE::Component::Physics::ColliderComponent::~ColliderComponent() {
-        auto* system = NNE::Systems::PhysicsSystem::GetInstance();
-        if (!bodyID.IsInvalid()) {
-                system->GetPhysicsSystem()->GetBodyInterface().RemoveBody(bodyID);
-                system->UnregisterCollider(bodyID);
-                bodyID = JPH::BodyID();
+        if (auto* system = NNE::Systems::PhysicsSystem::GetInstance()) {
+                if (!bodyID.IsInvalid()) {
+                        system->GetPhysicsSystem()->GetBodyInterface().RemoveBody(bodyID);
+                        system->UnregisterCollider(bodyID);
+                        bodyID = JPH::BodyID();
+                }
+                system->UnregisterComponent(this);
         }
-        system->UnregisterComponent(this);
 }
 
 

--- a/src/src/PhysicsSystem.cpp
+++ b/src/src/PhysicsSystem.cpp
@@ -101,6 +101,11 @@ void PhysicsSystem::Initialize() {
  * </summary>
  */
 PhysicsSystem::~PhysicsSystem() {
+  delete tempAllocator;
+  tempAllocator = nullptr;
+  delete jobSystem;
+  jobSystem = nullptr;
+  JPH::UnregisterTypes();
   delete JPH::Factory::sInstance;
   JPH::Factory::sInstance = nullptr;
   if (instance == this)

--- a/src/src/PhysicsSystem.cpp
+++ b/src/src/PhysicsSystem.cpp
@@ -117,7 +117,13 @@ PhysicsSystem::~PhysicsSystem() {
  * Fournit un accès au système physique Jolt.
  * </summary>
  */
-JPH::PhysicsSystem *PhysicsSystem::GetPhysicsSystem() { return &physicsSystem; }
+JPH::PhysicsSystem *PhysicsSystem::GetPhysicsSystem() {
+  if (!initialized) {
+    Initialize();
+    initialized = true;
+  }
+  return &physicsSystem;
+}
 
 PhysicsSystem* PhysicsSystem::GetInstance() { return instance; }
 

--- a/src/src/PlaneCollider.cpp
+++ b/src/src/PlaneCollider.cpp
@@ -6,7 +6,6 @@
 #include <Jolt/Physics/Body/MassProperties.h>
 
 #include "PhysicsSystem.h"
-#include "Application.h"
 #include "TransformComponent.h"
 #include "RigidbodyComponent.h"
 #include "AEntity.h"
@@ -59,9 +58,9 @@ void NNE::Component::Physics::PlaneCollider::CreateShape()
                 bodySettings.mMassPropertiesOverride.mInertia =
                     JPH::Mat44::sIdentity();
 
-                auto& bodyInterface = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem()->GetBodyInterface();
+                auto& bodyInterface = NNE::Systems::PhysicsSystem::GetInstance()->GetPhysicsSystem()->GetBodyInterface();
                 bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
 
-                NNE::Systems::Application::GetInstance()->RegisterCollider(bodyID, this);
+                NNE::Systems::PhysicsSystem::GetInstance()->RegisterCollider(bodyID, this);
         }
 }

--- a/src/src/RenderSystem.cpp
+++ b/src/src/RenderSystem.cpp
@@ -9,7 +9,7 @@ namespace NNE::Systems {
  * Initialise le système de rendu avec un gestionnaire Vulkan.
  * </summary>
  */
-RenderSystem::RenderSystem(VulkanManager* manager) : _vkManager(manager) {}
+RenderSystem::RenderSystem(VulkanManager* manager) : _renderer(manager) {}
 
 /**
  * <summary>
@@ -18,21 +18,9 @@ RenderSystem::RenderSystem(VulkanManager* manager) : _vkManager(manager) {}
  */
 void RenderSystem::Start()
 {
-    if (_vkManager)
+    if (_renderer)
     {
-        _vkManager->LoadMeshes(_renderObjects);
-
-        if (!_vkManager->vertices.empty() && !_vkManager->indices.empty())
-        {
-            _vkManager->createVertexBuffer();
-            _vkManager->createIndexBuffer();
-        }
-        _vkManager->createUniformBuffers();
-        _vkManager->createDescriptorPool();
-        _vkManager->createDescriptorSets();
-        _vkManager->createShadowDescriptorSets();
-        _vkManager->createCommandBuffers();
-        _vkManager->createSyncObjects();
+        _renderer->initializeRenderer(_renderObjects);
     }
 }
 
@@ -44,9 +32,9 @@ void RenderSystem::Start()
 void RenderSystem::Update(float deltaTime)
 {
     (void)deltaTime;
-    if (_vkManager)
+    if (_renderer)
     {
-        _vkManager->drawFrame(_renderObjects);
+        _renderer->renderFrame(_renderObjects);
     }
 }
 

--- a/src/src/RigidbodyComponent.cpp
+++ b/src/src/RigidbodyComponent.cpp
@@ -40,14 +40,15 @@ RigidbodyComponent::RigidbodyComponent(float mass,
  * </summary>
  */
 RigidbodyComponent::~RigidbodyComponent() {
-    auto* system = NNE::Systems::PhysicsSystem::GetInstance();
-    auto physicsSystem = system->GetPhysicsSystem();
-    if (!bodyID.IsInvalid()) {
-        physicsSystem->GetBodyInterface().RemoveBody(bodyID);
-        system->UnregisterCollider(bodyID);
-        bodyID = JPH::BodyID();
+    if (auto* system = NNE::Systems::PhysicsSystem::GetInstance()) {
+        if (!bodyID.IsInvalid()) {
+            auto* physicsSystem = system->GetPhysicsSystem();
+            physicsSystem->GetBodyInterface().RemoveBody(bodyID);
+            system->UnregisterCollider(bodyID);
+            bodyID = JPH::BodyID();
+        }
+        system->UnregisterComponent(this);
     }
-    system->UnregisterComponent(this);
 }
 
 /**

--- a/src/src/RigidbodyComponent.cpp
+++ b/src/src/RigidbodyComponent.cpp
@@ -4,7 +4,6 @@
 #include <Jolt/Jolt.h>
 
 #include "PhysicsSystem.h"
-#include "Application.h"
 #include "AEntity.h"
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
 #include <Jolt/Physics/Body/BodyInterface.h>
@@ -41,14 +40,14 @@ RigidbodyComponent::RigidbodyComponent(float mass,
  * </summary>
  */
 RigidbodyComponent::~RigidbodyComponent() {
-    auto app = NNE::Systems::Application::GetInstance();
-    auto physicsSystem = app->physicsSystem->GetPhysicsSystem();
+    auto* system = NNE::Systems::PhysicsSystem::GetInstance();
+    auto physicsSystem = system->GetPhysicsSystem();
     if (!bodyID.IsInvalid()) {
         physicsSystem->GetBodyInterface().RemoveBody(bodyID);
-        app->UnregisterCollider(bodyID);
+        system->UnregisterCollider(bodyID);
         bodyID = JPH::BodyID();
     }
-    app->physicsSystem->UnregisterComponent(this);
+    system->UnregisterComponent(this);
 }
 
 /**
@@ -57,7 +56,7 @@ RigidbodyComponent::~RigidbodyComponent() {
  * </summary>
  */
 void RigidbodyComponent::Awake() {
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::PhysicsSystem::GetInstance()->GetPhysicsSystem();
     auto const* transform = GetEntity()->GetComponent<NNE::Component::TransformComponent>();
     if (transform) {
         lastPosition = transform->position;
@@ -125,7 +124,7 @@ void RigidbodyComponent::Awake() {
     JPH::BodyInterface& bodyInterface = physicsSystem->GetBodyInterface();
     bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
     collider->bodyID = bodyID;
-    NNE::Systems::Application::GetInstance()->RegisterCollider(bodyID, collider);
+    NNE::Systems::PhysicsSystem::GetInstance()->RegisterCollider(bodyID, collider);
 }
 
 /**
@@ -161,7 +160,7 @@ JPH::BodyID RigidbodyComponent::GetBodyID() const {
  */
 void RigidbodyComponent::SetLinearVelocity(glm::vec3 velocity) {
 
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::PhysicsSystem::GetInstance()->GetPhysicsSystem();
     auto& bodyInterface = physicsSystem->GetBodyInterface();
     if (!bodyID.IsInvalid()) {
         bodyInterface.SetLinearVelocity(bodyID, JPH::RVec3(velocity.x, velocity.y, velocity.z));
@@ -169,7 +168,7 @@ void RigidbodyComponent::SetLinearVelocity(glm::vec3 velocity) {
 }
 
 void RigidbodyComponent::ApplyForce(glm::vec3 force, float deltaTime) {
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::PhysicsSystem::GetInstance()->GetPhysicsSystem();
     auto& bodyInterface = physicsSystem->GetBodyInterface();
     if (!bodyID.IsInvalid()) {
         // Jolt expects a force vector; scale by the duration to apply the impulse
@@ -179,7 +178,7 @@ void RigidbodyComponent::ApplyForce(glm::vec3 force, float deltaTime) {
 }
 
 void RigidbodyComponent::ApplyImpulse(glm::vec3 impulse) {
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::PhysicsSystem::GetInstance()->GetPhysicsSystem();
     auto& bodyInterface = physicsSystem->GetBodyInterface();
     if (!bodyID.IsInvalid()) {
         JPH::Vec3 joltImpulse(impulse.x, impulse.y, impulse.z);
@@ -198,7 +197,7 @@ void RigidbodyComponent::MoveKinematic(glm::vec3 position, glm::vec3 rotation, f
     if (!isKinematic)
         return;
 
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::PhysicsSystem::GetInstance()->GetPhysicsSystem();
     auto& bodyInterface = physicsSystem->GetBodyInterface();
     if (!bodyID.IsInvalid()) {
         glm::vec3 radians = glm::radians(rotation);
@@ -217,7 +216,7 @@ void RigidbodyComponent::MoveKinematic(glm::vec3 position, glm::vec3 rotation, f
  * </summary>
  */
 glm::vec3 RigidbodyComponent::GetLinearVelocity() const {
-    auto physicsSystem = NNE::Systems::Application::GetInstance()->physicsSystem->GetPhysicsSystem();
+    auto physicsSystem = NNE::Systems::PhysicsSystem::GetInstance()->GetPhysicsSystem();
     auto& bodyInterface = physicsSystem->GetBodyInterface();
     if (!bodyID.IsInvalid()) {
         JPH::RVec3 velocity = bodyInterface.GetLinearVelocity(bodyID);

--- a/src/src/SystemManager.cpp
+++ b/src/src/SystemManager.cpp
@@ -51,4 +51,50 @@ void SystemManager::RegisterComponent(NNE::Component::AComponent* component)
     }
 }
 
+void SystemManager::AwakeAll()
+{
+    for (ISystem* system : _systems)
+    {
+        system->Awake();
+    }
+}
+
+void SystemManager::StartAll()
+{
+    for (ISystem* system : _systems)
+    {
+        system->Start();
+    }
+}
+
+void SystemManager::UpdateAll(float deltaTime)
+{
+    for (ISystem* system : _systems)
+    {
+        system->Update(deltaTime);
+    }
+}
+
+void SystemManager::LateUpdateAll(float deltaTime)
+{
+    for (ISystem* system : _systems)
+    {
+        system->LateUpdate(deltaTime);
+    }
+}
+
+void SystemManager::Clear()
+{
+    for (ISystem* system : _systems)
+    {
+        delete system;
+    }
+    _systems.clear();
+}
+
+SystemManager::~SystemManager()
+{
+    Clear();
+}
+
 } // namespace NNE::Systems

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -1902,6 +1902,29 @@ void NNE::Systems::VulkanManager::createShadowDescriptorSets()
     }
 }
 
+void NNE::Systems::VulkanManager::initializeRenderer(const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& objects)
+{
+    LoadMeshes(objects);
+
+    if (!vertices.empty() && !indices.empty())
+    {
+        createVertexBuffer();
+        createIndexBuffer();
+    }
+
+    createUniformBuffers();
+    createDescriptorPool();
+    createDescriptorSets();
+    createShadowDescriptorSets();
+    createCommandBuffers();
+    createSyncObjects();
+}
+
+void NNE::Systems::VulkanManager::renderFrame(const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& objects)
+{
+    drawFrame(objects);
+}
+
 void NNE::Systems::VulkanManager::drawFrame(const std::vector<std::pair<NNE::Component::Render::MeshComponent*, NNE::Component::TransformComponent*>>& objects)
 {
     try {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,4 +1,5 @@
 #include "AComponent.h"
+#include "AComponent.h"
 #include "AEntity.h"
 #include "AScene.h"
 #include "Application.h"
@@ -94,10 +95,16 @@ static void test_get_components_multiple() {
   }
 }
 
-static void test_application_id_increment() {
-  int id1 = NNE::Systems::Application::GetInstance()->GenerateID();
-  int id2 = NNE::Systems::Application::GetInstance()->GenerateID();
-  EXPECT_TRUE(id2 == id1 + 1);
+static void test_entity_id_increment() {
+  NNE::AEntity e1;
+  NNE::AEntity e2;
+  EXPECT_TRUE(e2.GetID() == e1.GetID() + 1);
+}
+
+static void test_component_id_increment() {
+  NNE::Component::AComponent c1;
+  NNE::Component::AComponent c2;
+  EXPECT_TRUE(c2.GetID() == c1.GetID() + 1);
 }
 
 static void test_model_matrix_translation() {
@@ -127,7 +134,7 @@ static void test_rigidbody_awake_initializes_collider() {
 }
 
 static void test_collision_layers_matrix() {
-  auto *phys = NNE::Systems::Application::GetInstance()->physicsSystem;
+  auto *phys = NNE::Systems::PhysicsSystem::GetInstance();
   NNE::AEntity e;
   auto *pc = e.AddComponent<NNE::Component::Physics::PlaneCollider>(
       glm::vec3(0.0f, 1.0f, 0.0f), 0.0f);
@@ -148,7 +155,8 @@ int main() {
     void (*func)();
   };
   std::vector<TestCase> tests = {
-      {"application_id_increment", test_application_id_increment},
+      {"entity_id_increment", test_entity_id_increment},
+      {"component_id_increment", test_component_id_increment},
       {"default_transform", test_default_transform},
       {"parent_relationship", test_parent_relationship},
       {"transform_directions", test_transform_directions},


### PR DESCRIPTION
## Summary
- Expose singleton access for `PhysicsSystem` and let it track colliders internally
- Update physics components to register and query colliders through `PhysicsSystem`
- Remove redundant physics initialization from `Application`
- Simplify rendering by delegating initialization and per-frame work to `VulkanManager`
- Generate unique IDs within components and entities, eliminating `Application` dependency
- Run all engine systems through `SystemManager` with lifecycle helpers and type-safe lookup

