### PR TITLE
feat: add runtime shadow tuning

### DIFF
--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -116,7 +116,13 @@ namespace NNE::Systems {
     struct alignas(16) LightUBO {
         glm::vec3 dir;      float intensity; // 16B
         glm::vec3 color;    float ambient;   // 16B
-	};
+        };
+
+    struct ShadowConfig {
+        float margin = 10.0f;
+        float nearPlane = 0.1f;
+        float radiusFactor = 1.0f;
+    };
 
     class VulkanManager
 	{
@@ -213,6 +219,7 @@ namespace NNE::Systems {
         bool shadowDebugRequested;
 
     public :
+        ShadowConfig shadowConfig{};
         NNE::Component::Render::CameraComponent* activeCamera = nullptr;
         NNE::Component::Render::LightComponent* activeLight = nullptr;
         VkInstance instance = VK_NULL_HANDLE;

--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -85,6 +85,11 @@ void UISystem::Update(float deltaTime) {
                     } else {
                         ImGui::TextUnformatted("Shadow map unavailable");
                     }
+                    auto& cfg = _vkManager->shadowConfig;
+                    ImGui::Separator();
+                    ImGui::DragFloat("Margin", &cfg.margin, 0.1f, 0.0f, 1000.0f);
+                    ImGui::DragFloat("Near Plane", &cfg.nearPlane, 0.01f, 0.001f, 100.0f);
+                    ImGui::DragFloat("Radius Scale", &cfg.radiusFactor, 0.01f, 0.1f, 10.0f);
                     ImGui::EndTabItem();
                 }
 


### PR DESCRIPTION
## Summary
- allow runtime tuning of shadow projection via new `ShadowConfig`
- expose sliders for shadow frustum margin, near plane and radius scale in ImGui debug UI

