### PR TITLE
feat: add runtime shadow tuning

### DIFF
--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -116,7 +116,13 @@ namespace NNE::Systems {
     struct alignas(16) LightUBO {
         glm::vec3 dir;      float intensity; // 16B
         glm::vec3 color;    float ambient;   // 16B
-	};
+        };
+
+    struct ShadowConfig {
+        float margin = 10.0f;
+        float nearPlane = 0.1f;
+        float radiusFactor = 1.0f;
+    };
 
     class VulkanManager
 	{
@@ -203,6 +209,8 @@ namespace NNE::Systems {
         VkImageView shadowImageView;
         VkSampler shadowSampler;
         VkPipeline shadowPipeline;
+        // Tracks the current layout of shadowImage to ensure proper barriers
+        VkImageLayout shadowImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
         VkPipelineLayout shadowPipelineLayout;
         VkDescriptorSetLayout shadowDescriptorSetLayout;
@@ -213,6 +221,7 @@ namespace NNE::Systems {
         bool shadowDebugRequested;
 
     public :
+        ShadowConfig shadowConfig{};
         NNE::Component::Render::CameraComponent* activeCamera = nullptr;
         NNE::Component::Render::LightComponent* activeLight = nullptr;
         VkInstance instance = VK_NULL_HANDLE;

--- a/src/include/VulkanManager.h
+++ b/src/include/VulkanManager.h
@@ -119,9 +119,10 @@ namespace NNE::Systems {
         };
 
     struct ShadowConfig {
-        float margin = 10.0f;
-        float nearPlane = 0.1f;
-        float radiusFactor = 1.0f;
+        float orthoHalfSize = 100.0f;
+        float nearPlane = 1.0f;
+        float farPlane = 100.0f;
+        float lightDistance = 75.0f;
     };
 
     class VulkanManager

--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -87,9 +87,10 @@ void UISystem::Update(float deltaTime) {
                     }
                     auto& cfg = _vkManager->shadowConfig;
                     ImGui::Separator();
-                    ImGui::DragFloat("Margin", &cfg.margin, 0.1f, 0.0f, 1000.0f);
+                    ImGui::DragFloat("orthoHalfSize", &cfg.orthoHalfSize, 0.1f, 0.0f, 1000.0f);
                     ImGui::DragFloat("Near Plane", &cfg.nearPlane, 0.01f, 0.001f, 100.0f);
-                    ImGui::DragFloat("Radius Scale", &cfg.radiusFactor, 0.01f, 0.1f, 10.0f);
+                    ImGui::DragFloat("far Plane", &cfg.farPlane, 0.01f, 0.001f, 100.0f);
+                    ImGui::DragFloat("lightDistance", &cfg.lightDistance, 0.01f, 0.1f, 1000.0f);
                     ImGui::EndTabItem();
                 }
 

--- a/src/src/UISystem.cpp
+++ b/src/src/UISystem.cpp
@@ -85,6 +85,11 @@ void UISystem::Update(float deltaTime) {
                     } else {
                         ImGui::TextUnformatted("Shadow map unavailable");
                     }
+                    auto& cfg = _vkManager->shadowConfig;
+                    ImGui::Separator();
+                    ImGui::DragFloat("Margin", &cfg.margin, 0.1f, 0.0f, 1000.0f);
+                    ImGui::DragFloat("Near Plane", &cfg.nearPlane, 0.01f, 0.001f, 100.0f);
+                    ImGui::DragFloat("Radius Scale", &cfg.radiusFactor, 0.01f, 0.1f, 10.0f);
                     ImGui::EndTabItem();
                 }
 

--- a/src/src/VulkanManager.cpp
+++ b/src/src/VulkanManager.cpp
@@ -2679,14 +2679,22 @@ void NNE::Systems::VulkanManager::debugShadowMap()
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
         stagingBuffer, stagingBufferMemory);
 
-    transitionImageLayout(shadowImage, depthFormat,
-        shadowImageLayout,
-        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 1);
+    transitionImageLayout(
+        shadowImage,
+        depthFormat,
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        1);
     shadowImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+
     copyImageToBuffer(shadowImage, stagingBuffer, SHADOW_MAP_DIM, SHADOW_MAP_DIM);
-    transitionImageLayout(shadowImage, depthFormat,
-        shadowImageLayout,
-        VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, 1);
+
+    transitionImageLayout(
+        shadowImage,
+        depthFormat,
+        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+        1);
     shadowImageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
 
     void* data;


### PR DESCRIPTION
## Summary
- allow runtime tuning of shadow projection via new `ShadowConfig`
- expose sliders for shadow frustum margin, near plane and radius scale in ImGui debug UI
- track shadow map layout transitions to satisfy Vulkan validation

