### PR TITLE
Improve shader compilation script to use Vulkan SDK env var

### DIFF
--- a/src/shaders/compile.bat
+++ b/src/shaders/compile.bat
@@ -1,7 +1,17 @@
-C:/VulkanSDK/1.4.304.1/Bin/glslc.exe shader.vert -o vert.spv
-C:/VulkanSDK/1.4.304.1/Bin/glslc.exe shader.frag -o frag.spv
+@echo off
+setlocal
 
-C:/VulkanSDK/1.4.304.1/Bin/glslc.exe shadow.vert -o shadow_vert.spv
-C:/VulkanSDK/1.4.304.1/Bin/glslc.exe shadow.frag -o shadow_frag.spv
+REM Detect glslc path from VULKAN_SDK if available
+if defined VULKAN_SDK (
+    set "GLSLC=%VULKAN_SDK%\Bin\glslc.exe"
+) else (
+    echo [WARN] VULKAN_SDK not defined, using glslc from PATH.
+    set "GLSLC=glslc.exe"
+)
+
+"%GLSLC%" shader.vert -o vert.spv
+"%GLSLC%" shader.frag -o frag.spv
+"%GLSLC%" shadow.vert -o shadow_vert.spv
+"%GLSLC%" shadow.frag -o shadow_frag.spv
 
 pause


### PR DESCRIPTION
## Summary
- make shader compilation script locate `glslc` via the `VULKAN_SDK` variable or PATH
